### PR TITLE
docs: fix docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pnpm i @tresjs/post-processing
 
 ## Docs
 
-Checkout the [docs](https://postprocessing.tresjs.org/)
+Checkout the [docs](https://post-processing.tresjs.org/)
 
 ## Demos
 


### PR DESCRIPTION
Fix the link to the documentation website in the README.