### PR TITLE
feat: add hue & saturation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
           { text: 'Outline', link: '/guide/pmndrs/outline' },
           { text: 'Pixelation', link: '/guide/pmndrs/pixelation' },
           { text: 'Vignette', link: '/guide/pmndrs/vignette' },
+          { text: 'Hue & Saturation', link: '/guide/pmndrs/hue-saturation' },
         ],
       },
       {

--- a/docs/.vitepress/theme/components/pmdrs/HueSaturationDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/HueSaturationDemo.vue
@@ -1,50 +1,28 @@
 <script setup lang="ts">
-import { Environment, OrbitControls, useGLTF } from '@tresjs/cientos'
-import { dispose, TresCanvas } from '@tresjs/core'
+import { Environment, OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
 import { TresLeches, useControls } from '@tresjs/leches'
-import { EffectComposer } from '@tresjs/post-processing/pmndrs'
-import { ToneMappingMode } from 'postprocessing'
+import { EffectComposer, HueSaturation } from '@tresjs/post-processing/pmndrs'
+import { BlendFunction, ToneMappingMode } from 'postprocessing'
 import { NoToneMapping } from 'three'
-import { onUnmounted, shallowRef } from 'vue'
 
 import '@tresjs/leches/styles'
 
 const gl = {
-  toneMappingExposure: 1,
   toneMapping: NoToneMapping,
   multisampling: 8,
 }
 
-const modelRef = shallowRef(null)
-
-const { scene: model } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/realistic-pokeball/scene.gltf', { draco: true })
-
-const { toneMappingExposure, mode } = useControls({
-  toneMappingExposure: {
-    value: 1,
-    min: 0,
-    max: 10,
-    step: 1,
+const { saturation, hue, blendFunction } = useControls({
+  hue: { value: -Math.PI, min: -Math.PI, max: Math.PI, step: 0.001 },
+  saturation: { value: 1, min: -1, max: 1, step: 0.001 },
+  blendFunction: {
+    options: Object.keys(BlendFunction).map(key => ({
+      text: key,
+      value: BlendFunction[key],
+    })),
+    value: BlendFunction.SRC,
   },
-  mode: {
-    value: ToneMappingMode.AGX,
-    options: [
-      { text: 'LINEAR', value: ToneMappingMode.LINEAR },
-      { text: 'REINHARD', value: ToneMappingMode.REINHARD },
-      { text: 'REINHARD2', value: ToneMappingMode.REINHARD2 },
-      { text: 'REINHARD2_ADAPTIVE', value: ToneMappingMode.REINHARD2_ADAPTIVE },
-      { text: 'UNCHARTED2', value: ToneMappingMode.UNCHARTED2 },
-      { text: 'OPTIMIZED_CINEON', value: ToneMappingMode.OPTIMIZED_CINEON },
-      { text: 'CINEON', value: ToneMappingMode.CINEON },
-      { text: 'ACES_FILMIC', value: ToneMappingMode.ACES_FILMIC },
-      { text: 'AGX', value: ToneMappingMode.AGX },
-      { text: 'NEUTRAL', value: ToneMappingMode.NEUTRAL },
-    ],
-  },
-})
-
-onUnmounted(() => {
-  dispose(model)
 })
 </script>
 
@@ -53,7 +31,6 @@ onUnmounted(() => {
 
   <TresCanvas
     v-bind="gl"
-    :toneMappingExposure="toneMappingExposure.value"
   >
     <TresPerspectiveCamera
       :position="[5, 5, 5]"
@@ -61,15 +38,18 @@ onUnmounted(() => {
     />
     <OrbitControls auto-rotate />
 
-    <primitive ref="modelRef" :object="model" :position-y="-.5" :scale=".25" />
+    <TresMesh :position="[0, 1, 0]">
+      <TresBoxGeometry :args="[2, 2, 2]" />
+      <TresMeshPhysicalMaterial color="white" />
+    </TresMesh>
 
     <Suspense>
-      <Environment :intensity="2" background :blur=".25" preset="dawn" />
+      <Environment background :blur=".25" preset="modern" />
     </Suspense>
 
     <Suspense>
       <EffectComposer>
-        <!-- <ToneMapping :mode="Number(mode.value)" /> -->
+        <HueSaturation :blendFunction="Number(blendFunction.value)" :hue="hue.value" :saturation="saturation.value" />
       </EffectComposer>
     </Suspense>
   </TresCanvas>

--- a/docs/.vitepress/theme/components/pmdrs/HueSaturationDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/HueSaturationDemo.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { Environment, OrbitControls, useGLTF } from '@tresjs/cientos'
+import { dispose, TresCanvas } from '@tresjs/core'
+import { TresLeches, useControls } from '@tresjs/leches'
+import { EffectComposer } from '@tresjs/post-processing/pmndrs'
+import { ToneMappingMode } from 'postprocessing'
+import { NoToneMapping } from 'three'
+import { onUnmounted, shallowRef } from 'vue'
+
+import '@tresjs/leches/styles'
+
+const gl = {
+  toneMappingExposure: 1,
+  toneMapping: NoToneMapping,
+  multisampling: 8,
+}
+
+const modelRef = shallowRef(null)
+
+const { scene: model } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/realistic-pokeball/scene.gltf', { draco: true })
+
+const { toneMappingExposure, mode } = useControls({
+  toneMappingExposure: {
+    value: 1,
+    min: 0,
+    max: 10,
+    step: 1,
+  },
+  mode: {
+    value: ToneMappingMode.AGX,
+    options: [
+      { text: 'LINEAR', value: ToneMappingMode.LINEAR },
+      { text: 'REINHARD', value: ToneMappingMode.REINHARD },
+      { text: 'REINHARD2', value: ToneMappingMode.REINHARD2 },
+      { text: 'REINHARD2_ADAPTIVE', value: ToneMappingMode.REINHARD2_ADAPTIVE },
+      { text: 'UNCHARTED2', value: ToneMappingMode.UNCHARTED2 },
+      { text: 'OPTIMIZED_CINEON', value: ToneMappingMode.OPTIMIZED_CINEON },
+      { text: 'CINEON', value: ToneMappingMode.CINEON },
+      { text: 'ACES_FILMIC', value: ToneMappingMode.ACES_FILMIC },
+      { text: 'AGX', value: ToneMappingMode.AGX },
+      { text: 'NEUTRAL', value: ToneMappingMode.NEUTRAL },
+    ],
+  },
+})
+
+onUnmounted(() => {
+  dispose(model)
+})
+</script>
+
+<template>
+  <TresLeches style="left: initial;right:10px; top:10px;" />
+
+  <TresCanvas
+    v-bind="gl"
+    :toneMappingExposure="toneMappingExposure.value"
+  >
+    <TresPerspectiveCamera
+      :position="[5, 5, 5]"
+      :look-at="[0, 0, 0]"
+    />
+    <OrbitControls auto-rotate />
+
+    <primitive ref="modelRef" :object="model" :position-y="-.5" :scale=".25" />
+
+    <Suspense>
+      <Environment :intensity="2" background :blur=".25" preset="dawn" />
+    </Suspense>
+
+    <Suspense>
+      <EffectComposer>
+        <!-- <ToneMapping :mode="Number(mode.value)" /> -->
+      </EffectComposer>
+    </Suspense>
+  </TresCanvas>
+</template>

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -27,5 +27,6 @@ declare module 'vue' {
     SMAAThreeDemo: typeof import('./.vitepress/theme/components/three/SMAAThreeDemo.vue')['default']
     UnrealBloomThreeDemo: typeof import('./.vitepress/theme/components/three/UnrealBloomThreeDemo.vue')['default']
     VignetteDemo: typeof import('./.vitepress/theme/components/pmdrs/VignetteDemo.vue')['default']
+    HueSaturation: typeof import('./.vitepress/theme/components/pmdrs/HueSaturationDemo.vue')['default']
   }
 }

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -17,6 +17,8 @@ declare module 'vue' {
     GlitchThreeDemo: typeof import('./.vitepress/theme/components/three/GlitchThreeDemo.vue')['default']
     GlitchTreeDemo: typeof import('./.vitepress/theme/components/three/GlitchTreeDemo.vue')['default']
     HalftoneThreeDemo: typeof import('./.vitepress/theme/components/three/HalftoneThreeDemo.vue')['default']
+    HueSaturation: typeof import('./.vitepress/theme/components/pmdrs/HueSaturationDemo.vue')['default']
+    HueSaturationDemo: typeof import('./.vitepress/theme/components/pmdrs/HueSaturationDemo.vue')['default']
     LoveVueThreeJS: typeof import('./.vitepress/theme/components/LoveVueThreeJS.vue')['default']
     NoiseDemo: typeof import('./.vitepress/theme/components/pmdrs/NoiseDemo.vue')['default']
     OutlineDemo: typeof import('./.vitepress/theme/components/pmdrs/OutlineDemo.vue')['default']
@@ -27,6 +29,5 @@ declare module 'vue' {
     SMAAThreeDemo: typeof import('./.vitepress/theme/components/three/SMAAThreeDemo.vue')['default']
     UnrealBloomThreeDemo: typeof import('./.vitepress/theme/components/three/UnrealBloomThreeDemo.vue')['default']
     VignetteDemo: typeof import('./.vitepress/theme/components/pmdrs/VignetteDemo.vue')['default']
-    HueSaturation: typeof import('./.vitepress/theme/components/pmdrs/HueSaturationDemo.vue')['default']
   }
 }

--- a/docs/guide/pmndrs/hue-saturation.md
+++ b/docs/guide/pmndrs/hue-saturation.md
@@ -1,0 +1,70 @@
+# ToneMapping
+
+<DocsDemo>
+  <ToneMappingDemo />
+</DocsDemo>
+
+The `ToneMapping` effect from the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html) package provides an abstraction for various tone mapping algorithms to improve the visual rendering of HDR (high dynamic range) content. Tone mapping is used to map high-range brightness values to a range that is displayable on standard screens. This effect contributes significantly to the visual quality of your scene by controlling luminance and color balance.
+
+::: info
+If the colors in your scene look incorrect after adding the EffectComposer, it might be because tone mapping is deactivated by default, which is normal behavior. Add `<ToneMapping>` manually as an effect at the end of the `<EffectComposer>` to fix this.
+:::
+
+## Usage
+
+The `<ToneMapping>` component is easy to set up and comes with multiple tone mapping modes to suit different visual requirements. Below is an example of how to use it in a Vue application.
+
+```vue{2,4,7-8,32-35}
+<script setup lang="ts">
+import { EffectComposer } from '@tresjs/post-processing/pmndrs'
+import { onUnmounted, shallowRef } from 'vue'
+import { ToneMappingMode } from 'postprocessing'
+
+const gl = {
+  toneMappingExposure: 1,
+  toneMapping: NoToneMapping,
+  multisampling: 8,
+}
+
+const modelRef = shallowRef(null)
+
+const { scene: model } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/realistic-pokeball/scene.gltf', { draco: true })
+
+onUnmounted(() => {
+  dispose(modelRef.value)
+})
+</script>
+
+<template>
+  <TresCanvas
+    v-bind="gl"
+  >
+    <TresPerspectiveCamera
+      :position="[5, 5, 5]"
+      :look-at="[0, 0, 0]"
+    />
+
+    <primitive ref="modelRef" :object="model" />
+
+    <EffectComposer>
+      <!-- For example, here the ToneMappingMode.UNCHARTED2 mode -->
+      <!-- <ToneMapping :mode="ToneMappingMode.UNCHARTED2" /> -->
+    </EffectComposer>
+  </TresCanvas>
+</template>
+```
+
+## Props
+
+| Prop              | Description                                                                                                   | Default                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| mode              | Tone mapping mode used, defined by [`ToneMappingMode`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-ToneMappingMode).                                                         | `ToneMappingMode.AGX`                                                                             |
+| blendFunction     | Defines the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) used for the effect.                                                               | `BlendFunction.SRC`                                                                               |
+| resolution        | Resolution of the luminance texture (must be a power of two, e.g., 256, 512, etc.).                           | `256`                                                                                             |
+| averageLuminance  | Average luminance value used in adaptive calculations. Only applicable to `ToneMappingMode.REINHARD2`                        | `1.0`                                                                                             |
+| middleGrey        | Factor to adjust the balance of grey in luminance calculations. Only applicable to `ToneMappingMode.REINHARD2`               | `0.6`                                                                                             |
+| minLuminance      | Lower luminance limit, used to avoid overexposure effects in dark scenes. Only applicable to `ToneMappingMode.REINHARD2`     | `0.01`                                                                                            |
+| whitePoint        | White point for tone mapping, used to balance luminance values. Only applicable to `ToneMappingMode.REINHARD2`               | `4.0`                                                                                             |
+
+## Further Reading
+see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html)

--- a/docs/guide/pmndrs/hue-saturation.md
+++ b/docs/guide/pmndrs/hue-saturation.md
@@ -1,70 +1,60 @@
-# ToneMapping
+# HueSaturation
 
 <DocsDemo>
-  <ToneMappingDemo />
+  <HueSaturationDemo />
 </DocsDemo>
 
-The `ToneMapping` effect from the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html) package provides an abstraction for various tone mapping algorithms to improve the visual rendering of HDR (high dynamic range) content. Tone mapping is used to map high-range brightness values to a range that is displayable on standard screens. This effect contributes significantly to the visual quality of your scene by controlling luminance and color balance.
-
-::: info
-If the colors in your scene look incorrect after adding the EffectComposer, it might be because tone mapping is deactivated by default, which is normal behavior. Add `<ToneMapping>` manually as an effect at the end of the `<EffectComposer>` to fix this.
-:::
+The `HueSaturation` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/HueSaturationEffect.js~HueSaturationEffect.html) package. It allows you to adjust the hue and saturation of your scene, providing flexibility for color grading and artistic effects.
 
 ## Usage
 
-The `<ToneMapping>` component is easy to set up and comes with multiple tone mapping modes to suit different visual requirements. Below is an example of how to use it in a Vue application.
+The `<HueSaturation>` component is straightforward to use and provides customizable options to fine-tune the hue and saturation of your visuals.
 
-```vue{2,4,7-8,32-35}
+```vue{2,5-9,26-32}
 <script setup lang="ts">
-import { EffectComposer } from '@tresjs/post-processing/pmndrs'
-import { onUnmounted, shallowRef } from 'vue'
-import { ToneMappingMode } from 'postprocessing'
+import { HueSaturation } from '@tresjs/post-processing/pmndrs'
+import { BlendFunction } from 'postprocessing'
 
-const gl = {
-  toneMappingExposure: 1,
-  toneMapping: NoToneMapping,
-  multisampling: 8,
+const effectProps = {
+  saturation: 1,
+  hue: -Math.PI,
+  blendFunction: BlendFunction.SRC,
 }
-
-const modelRef = shallowRef(null)
-
-const { scene: model } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/realistic-pokeball/scene.gltf', { draco: true })
-
-onUnmounted(() => {
-  dispose(modelRef.value)
-})
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas>
     <TresPerspectiveCamera
       :position="[5, 5, 5]"
       :look-at="[0, 0, 0]"
     />
 
-    <primitive ref="modelRef" :object="model" />
+    <OrbitControls auto-rotate />
 
-    <EffectComposer>
-      <!-- For example, here the ToneMappingMode.UNCHARTED2 mode -->
-      <!-- <ToneMapping :mode="ToneMappingMode.UNCHARTED2" /> -->
-    </EffectComposer>
+    <TresMesh :position="[0, 1, 0]">
+      <TresBoxGeometry :args="[2, 2, 2]" />
+      <TresMeshPhysicalMaterial color="white" />
+    </TresMesh>
+
+    <Suspense>
+      <EffectComposer>
+        <HueSaturation
+          v-bind="effectProps"
+        />
+      </EffectComposer>
+    </Suspense>
   </TresCanvas>
 </template>
 ```
 
 ## Props
 
-| Prop              | Description                                                                                                   | Default                                                                                           |
-| ----------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| mode              | Tone mapping mode used, defined by [`ToneMappingMode`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-ToneMappingMode).                                                         | `ToneMappingMode.AGX`                                                                             |
-| blendFunction     | Defines the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) used for the effect.                                                               | `BlendFunction.SRC`                                                                               |
-| resolution        | Resolution of the luminance texture (must be a power of two, e.g., 256, 512, etc.).                           | `256`                                                                                             |
-| averageLuminance  | Average luminance value used in adaptive calculations. Only applicable to `ToneMappingMode.REINHARD2`                        | `1.0`                                                                                             |
-| middleGrey        | Factor to adjust the balance of grey in luminance calculations. Only applicable to `ToneMappingMode.REINHARD2`               | `0.6`                                                                                             |
-| minLuminance      | Lower luminance limit, used to avoid overexposure effects in dark scenes. Only applicable to `ToneMappingMode.REINHARD2`     | `0.01`                                                                                            |
-| whitePoint        | White point for tone mapping, used to balance luminance values. Only applicable to `ToneMappingMode.REINHARD2`               | `4.0`                                                                                             |
+| Prop           | Description                                                                                                                                                                  | Default                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| **saturation** | The saturation adjustment. A value of `0.0` results in grayscale, while `1.0` leaves saturation unchanged. Range: `[0.0, 1.0]`.                                               | `0.0`                    |
+| **hue**        | The hue adjustment in radians. Values range from `[-π, π]` (or `[0, 2π]` for a full rotation).                                                                               | `0.0`                    |
+| **blendFunction** | Defines how the effect blends with the original scene. See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options. | `BlendFunction.SRC`      |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html)
+
+For more details, see the [HueSaturation documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/HueSaturationEffect.js~HueSaturationEffect.html).

--- a/playground/src/pages/postprocessing/hue-saturation.vue
+++ b/playground/src/pages/postprocessing/hue-saturation.vue
@@ -2,8 +2,8 @@
 import { Environment, OrbitControls } from '@tresjs/cientos'
 import { TresCanvas } from '@tresjs/core'
 import { TresLeches, useControls } from '@tresjs/leches'
-import { EffectComposer } from '@tresjs/post-processing/pmndrs'
-import { ToneMappingMode } from 'postprocessing'
+import { EffectComposer, HueSaturation } from '@tresjs/post-processing/pmndrs'
+import { BlendFunction, ToneMappingMode } from 'postprocessing'
 import { NoToneMapping } from 'three'
 
 import '@tresjs/leches/styles'
@@ -13,32 +13,15 @@ const gl = {
   multisampling: 8,
 }
 
-const { resolution, mode } = useControls({
-
-  mode: {
-    value: ToneMappingMode.AGX,
-    options: [
-      { text: 'LINEAR', value: ToneMappingMode.LINEAR },
-      { text: 'REINHARD', value: ToneMappingMode.REINHARD },
-      { text: 'REINHARD2', value: ToneMappingMode.REINHARD2 },
-      { text: 'REINHARD2_ADAPTIVE', value: ToneMappingMode.REINHARD2_ADAPTIVE },
-      { text: 'UNCHARTED2', value: ToneMappingMode.UNCHARTED2 },
-      { text: 'OPTIMIZED_CINEON', value: ToneMappingMode.OPTIMIZED_CINEON },
-      { text: 'CINEON', value: ToneMappingMode.CINEON },
-      { text: 'ACES_FILMIC', value: ToneMappingMode.ACES_FILMIC },
-      { text: 'AGX', value: ToneMappingMode.AGX },
-      { text: 'NEUTRAL', value: ToneMappingMode.NEUTRAL },
-    ],
-  },
-  resolution: {
-    value: 256,
-    options: [
-      { text: '128', value: 128 },
-      { text: '256', value: 256 },
-      { text: '512', value: 512 },
-      { text: '1024', value: 1024 },
-      { text: '2048', value: 2048 },
-    ],
+const { saturation, hue, blendFunction } = useControls({
+  hue: { value: 0, min: -Math.PI, max: Math.PI, step: 0.001 },
+  saturation: { value: 0, min: -1, max: 1, step: 0.001 },
+  blendFunction: {
+    options: Object.keys(BlendFunction).map(key => ({
+      text: key,
+      value: BlendFunction[key],
+    })),
+    value: BlendFunction.SRC,
   },
 })
 </script>
@@ -57,17 +40,17 @@ const { resolution, mode } = useControls({
 
     <TresMesh :position="[0, 1, 0]">
       <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshPhysicalMaterial color="#F57BAD" :roughness=".25" :transmission=".85" />
+      <TresMeshPhysicalMaterial color="white" :roughness="1" :transmission="0" />
     </TresMesh>
 
     <Suspense>
-      <Environment :intensity="2" background :blur=".25" preset="dawn" />
+      <Environment background :blur=".25" preset="modern" />
     </Suspense>
 
     <Suspense>
-      <!-- <EffectComposer> -->
-      <!-- <ToneMapping :mode="Number(mode.value)" :resolution="Number(resolution.value)" /> -->
-      <!-- </EffectComposer> -->
+      <EffectComposer>
+        <HueSaturation :blendFunction="Number(blendFunction.value)" :hue="hue.value" :saturation="saturation.value" />
+      </EffectComposer>
     </Suspense>
   </TresCanvas>
 </template>

--- a/playground/src/pages/postprocessing/hue-saturation.vue
+++ b/playground/src/pages/postprocessing/hue-saturation.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { Environment, OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { TresLeches, useControls } from '@tresjs/leches'
+import { EffectComposer } from '@tresjs/post-processing/pmndrs'
+import { ToneMappingMode } from 'postprocessing'
+import { NoToneMapping } from 'three'
+
+import '@tresjs/leches/styles'
+
+const gl = {
+  toneMapping: NoToneMapping,
+  multisampling: 8,
+}
+
+const { resolution, mode } = useControls({
+
+  mode: {
+    value: ToneMappingMode.AGX,
+    options: [
+      { text: 'LINEAR', value: ToneMappingMode.LINEAR },
+      { text: 'REINHARD', value: ToneMappingMode.REINHARD },
+      { text: 'REINHARD2', value: ToneMappingMode.REINHARD2 },
+      { text: 'REINHARD2_ADAPTIVE', value: ToneMappingMode.REINHARD2_ADAPTIVE },
+      { text: 'UNCHARTED2', value: ToneMappingMode.UNCHARTED2 },
+      { text: 'OPTIMIZED_CINEON', value: ToneMappingMode.OPTIMIZED_CINEON },
+      { text: 'CINEON', value: ToneMappingMode.CINEON },
+      { text: 'ACES_FILMIC', value: ToneMappingMode.ACES_FILMIC },
+      { text: 'AGX', value: ToneMappingMode.AGX },
+      { text: 'NEUTRAL', value: ToneMappingMode.NEUTRAL },
+    ],
+  },
+  resolution: {
+    value: 256,
+    options: [
+      { text: '128', value: 128 },
+      { text: '256', value: 256 },
+      { text: '512', value: 512 },
+      { text: '1024', value: 1024 },
+      { text: '2048', value: 2048 },
+    ],
+  },
+})
+</script>
+
+<template>
+  <TresLeches />
+
+  <TresCanvas
+    v-bind="gl"
+  >
+    <TresPerspectiveCamera
+      :position="[5, 5, 5]"
+      :look-at="[0, 0, 0]"
+    />
+    <OrbitControls auto-rotate />
+
+    <TresMesh :position="[0, 1, 0]">
+      <TresBoxGeometry :args="[2, 2, 2]" />
+      <TresMeshPhysicalMaterial color="#F57BAD" :roughness=".25" :transmission=".85" />
+    </TresMesh>
+
+    <Suspense>
+      <Environment :intensity="2" background :blur=".25" preset="dawn" />
+    </Suspense>
+
+    <Suspense>
+      <!-- <EffectComposer> -->
+      <!-- <ToneMapping :mode="Number(mode.value)" :resolution="Number(resolution.value)" /> -->
+      <!-- </EffectComposer> -->
+    </Suspense>
+  </TresCanvas>
+</template>

--- a/playground/src/router.ts
+++ b/playground/src/router.ts
@@ -35,6 +35,7 @@ export const postProcessingRoutes = [
   makeRoute('Outline', '🔲', false),
   makeRoute('Glitch', '📺', false),
   makeRoute('Depth of Field', '📷', false),
+  makeRoute('Hue & Saturation', '📷', false),
   makeRoute('Pixelation', '👾', false),
   makeRoute('Bloom', '🌼', false),
   makeRoute('Noise', '📟', false),

--- a/src/core/pmndrs/HueSaturation.vue
+++ b/src/core/pmndrs/HueSaturation.vue
@@ -1,74 +1,54 @@
 <script lang="ts" setup>
-import { BlendFunction, ToneMappingEffect, ToneMappingMode } from 'postprocessing'
-import { defineExpose, defineProps, withDefaults } from 'vue'
+import { BlendFunction, HueSaturationEffect } from 'postprocessing'
+import { defineExpose, defineProps, watchEffect, withDefaults } from 'vue'
 import { useEffect } from './composables/useEffect'
 import { makePropWatchers } from '../../util/prop'
 
 export interface HueSaturationProps {
   /**
-   * The tone mapping mode.
+   * The saturation adjustment. A value of 0.0 results in grayscale, and 1.0 leaves saturation unchanged.
+   * Range: [0.0, 1.0]
    */
-  mode?: ToneMappingMode
+  saturation?: number
 
   /**
-   * The blend function.
+   * The hue adjustment in radians.
+   * Range: [-π, π] (or [0, 2π] for a full rotation)
+   */
+  hue?: number
+
+  /**
+   * The blend function. Defines how the effect blends with the original scene.
    */
   blendFunction?: BlendFunction
 
-  /**
-   * The resolution for luminance texture. The resolution of the luminance texture. Must be a power of two.
-   */
-  resolution?: number
-
-  /**
-   * The average luminance. Only for `REINHARD2`.
-   */
-  averageLuminance?: number
-
-  /**
-   * The middle grey factor. Only for `REINHARD2`.
-   */
-  middleGrey?: number
-
-  /**
-   * The minimum luminance. Only for `REINHARD2`.
-   */
-  minLuminance?: number
-
-  /**
-   * The white point. Only for `REINHARD2`.
-   */
-  whitePoint?: number
 }
 
 const props = withDefaults(
   defineProps<HueSaturationProps>(),
   {
-    mode: ToneMappingMode.AGX,
+    saturation: 0.0,
+    hue: 0.0,
     blendFunction: BlendFunction.SRC,
-    resolution: 256,
-    averageLuminance: 1.0,
-    middleGrey: 0.6,
-    minLuminance: 0.01,
-    whitePoint: 4.0,
   },
 )
 
-const { pass, effect } = useEffect(() => new ToneMappingEffect(props), props)
+const { pass, effect } = useEffect(() => new HueSaturationEffect(props), props)
 
 defineExpose({ pass, effect })
 
 makePropWatchers(
   [
-    [() => props.mode, 'mode'],
-    [() => props.blendFunction, 'blendFunction'],
-    [() => props.resolution, 'resolution'],
-    [() => props.averageLuminance, 'averageLuminance'],
-    [() => props.middleGrey, 'middleGrey'],
-    [() => props.minLuminance, 'minLuminance'],
-    [() => props.whitePoint, 'whitePoint'],
+    [() => props.hue, 'hue'],
+    [() => props.saturation, 'saturation'],
   ],
   effect,
-  () => new ToneMappingEffect(),
+  () => new HueSaturationEffect(),
 )
+
+watchEffect(() => {
+  if (!effect.value) { return }
+
+  effect.value.blendMode.blendFunction = Number(props.blendFunction)
+})
 </script>

--- a/src/core/pmndrs/HueSaturation.vue
+++ b/src/core/pmndrs/HueSaturation.vue
@@ -1,0 +1,74 @@
+<script lang="ts" setup>
+import { BlendFunction, ToneMappingEffect, ToneMappingMode } from 'postprocessing'
+import { defineExpose, defineProps, withDefaults } from 'vue'
+import { useEffect } from './composables/useEffect'
+import { makePropWatchers } from '../../util/prop'
+
+export interface HueSaturationProps {
+  /**
+   * The tone mapping mode.
+   */
+  mode?: ToneMappingMode
+
+  /**
+   * The blend function.
+   */
+  blendFunction?: BlendFunction
+
+  /**
+   * The resolution for luminance texture. The resolution of the luminance texture. Must be a power of two.
+   */
+  resolution?: number
+
+  /**
+   * The average luminance. Only for `REINHARD2`.
+   */
+  averageLuminance?: number
+
+  /**
+   * The middle grey factor. Only for `REINHARD2`.
+   */
+  middleGrey?: number
+
+  /**
+   * The minimum luminance. Only for `REINHARD2`.
+   */
+  minLuminance?: number
+
+  /**
+   * The white point. Only for `REINHARD2`.
+   */
+  whitePoint?: number
+}
+
+const props = withDefaults(
+  defineProps<HueSaturationProps>(),
+  {
+    mode: ToneMappingMode.AGX,
+    blendFunction: BlendFunction.SRC,
+    resolution: 256,
+    averageLuminance: 1.0,
+    middleGrey: 0.6,
+    minLuminance: 0.01,
+    whitePoint: 4.0,
+  },
+)
+
+const { pass, effect } = useEffect(() => new ToneMappingEffect(props), props)
+
+defineExpose({ pass, effect })
+
+makePropWatchers(
+  [
+    [() => props.mode, 'mode'],
+    [() => props.blendFunction, 'blendFunction'],
+    [() => props.resolution, 'resolution'],
+    [() => props.averageLuminance, 'averageLuminance'],
+    [() => props.middleGrey, 'middleGrey'],
+    [() => props.minLuminance, 'minLuminance'],
+    [() => props.whitePoint, 'whitePoint'],
+  ],
+  effect,
+  () => new ToneMappingEffect(),
+)
+</script>

--- a/src/core/pmndrs/index.ts
+++ b/src/core/pmndrs/index.ts
@@ -9,6 +9,7 @@ import Noise, { type NoiseProps } from './Noise.vue'
 import Outline, { type OutlineProps } from './Outline.vue'
 import Pixelation, { type PixelationProps } from './Pixelation.vue'
 import Vignette, { type VignetteProps } from './Vignette.vue'
+import HueSaturation, { type HueSaturationProps } from './HueSaturation.vue'
 
 export {
   Bloom,
@@ -20,6 +21,7 @@ export {
   Pixelation,
   useEffect,
   Vignette,
+  HueSaturation,
 
   BloomProps,
   DepthOfFieldProps,
@@ -29,4 +31,5 @@ export {
   OutlineProps,
   PixelationProps,
   VignetteProps,
+  HueSaturationProps,
 }


### PR DESCRIPTION
This component introduces the `<HueSaturation>` effect, which adjusts the hue and saturation of your scene, allowing for advanced color grading and stylized visuals. The `<HueSaturation>` effect is part of the [`pmndrs/postprocessing`](https://github.com/pmndrs/postprocessing) package and can enhance your project with dynamic and vibrant color adjustments.

- Fine-tunes the visual appeal of your scene with customizable hue and saturation adjustments.
- Easy to set up — simply include it in your `<EffectComposer>` pipeline.
- Fully supports different blend functions for enhanced visual styles.

For more details, see [HueSaturationEffect](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/HueSaturationEffect.js~HueSaturationEffect.html) on [pmndrs/postprocessing](https://github.com/pmndrs/postprocessing).

---

**Local Playground** — `pnpm run playground`

**Local Documentation** — `pnpm run docs:dev`
