### PR TITLE
feat: add tilt shift effect

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
           { text: 'Pixelation', link: '/guide/pmndrs/pixelation' },
           { text: 'Vignette', link: '/guide/pmndrs/vignette' },
           { text: 'Hue & Saturation', link: '/guide/pmndrs/hue-saturation' },
+          { text: 'Tilt Shift', link: '/guide/pmndrs/tilt-shift' },
         ],
       },
       {

--- a/docs/.vitepress/theme/components/pmdrs/TiltShiftDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/TiltShiftDemo.vue
@@ -5,7 +5,6 @@ import { TresLeches, useControls } from '@tresjs/leches'
 import { EffectComposerPmndrs, TiltShiftPmndrs } from '@tresjs/post-processing'
 import { BlendFunction } from 'postprocessing'
 import { NoToneMapping } from 'three'
-import { ref } from 'vue'
 
 import '@tresjs/leches/styles'
 

--- a/docs/.vitepress/theme/components/pmdrs/TiltShiftDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/TiltShiftDemo.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { ContactShadows, Environment, OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { TresLeches, useControls } from '@tresjs/leches'
+import { EffectComposerPmndrs, TiltShiftPmndrs } from '@tresjs/post-processing'
+import { BlendFunction } from 'postprocessing'
+import { NoToneMapping } from 'three'
+import { ref } from 'vue'
+
+import '@tresjs/leches/styles'
+
+const gl = {
+  toneMapping: NoToneMapping,
+  multisampling: 8,
+}
+
+const colors = [
+  '#FF5733',
+  '#33FF57',
+  '#3357FF',
+  '#FF33A1',
+  '#33FFF5',
+  '#FF5733',
+  '#FF8D33',
+]
+
+const { blendFunction, offset, rotation, focusArea, feather } = useControls({
+  blendFunction: {
+    options: Object.keys(BlendFunction).map(key => ({
+      text: key,
+      value: BlendFunction[key],
+    })),
+    value: BlendFunction.NORMAL,
+  },
+  offset: { value: 0.0, min: -0.5, max: 0.5, step: 0.01 },
+  rotation: { value: 0.0, min: -Math.PI, max: Math.PI, step: 0.01 },
+  focusArea: { value: 0.7, min: 0, max: 1, step: 0.01 },
+  feather: { value: 0.2, min: 0, max: 1, step: 0.01 },
+})
+</script>
+
+<template>
+  <TresLeches style="left: initial;right:10px; top:10px;" />
+
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[0, 8, 4]" />
+    <OrbitControls auto-rotate />
+
+    <template v-for="index in 50" :key="index">
+      <TresMesh :position="[(index % 10) * 3 - 13.5, 0, Math.floor(index / 10) * 3 - 7.5]" :scale="[2, Math.random() * 5 + 2, 2]">
+        <TresBoxGeometry :args="[1, 1, 1]" />
+        <TresMeshPhysicalMaterial
+          :color="colors[index % colors.length]"
+          :roughness="0.35"
+          :metalness="0.5"
+          :clearcoat="0.3"
+          :clearcoatRoughness="0.25"
+        />
+      </TresMesh>
+    </template>
+
+    <Suspense>
+      <Environment background :blur=".35" preset="city" />
+    </Suspense>
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <TiltShiftPmndrs
+          :blendFunction="Number(blendFunction.value)"
+          :offset="offset.value"
+          :rotation="rotation.value"
+          :focusArea="focusArea.value"
+          :feather="feather.value"
+        />
+      </EffectComposerPmndrs>
+    </Suspense>
+
+    <ContactShadows
+      :opacity=".75"
+      :position-y="-3.5"
+      :scale="20"
+      :blur=".1"
+      :far="15"
+    />
+  </TresCanvas>
+</template>

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -25,6 +25,7 @@ declare module 'vue' {
     PixelationThreeDemo: typeof import('./.vitepress/theme/components/three/PixelationThreeDemo.vue')['default']
     ScanlineDemo: typeof import('./.vitepress/theme/components/pmdrs/ScanlineDemo.vue')['default']
     SMAAThreeDemo: typeof import('./.vitepress/theme/components/three/SMAAThreeDemo.vue')['default']
+    TiltShiftDemo: typeof import('./.vitepress/theme/components/pmdrs/TiltShiftDemo.vue')['default']
     ToneMappingDemo: typeof import('./.vitepress/theme/components/pmdrs/ToneMappingDemo.vue')['default']
     UnrealBloomThreeDemo: typeof import('./.vitepress/theme/components/three/UnrealBloomThreeDemo.vue')['default']
     VignetteDemo: typeof import('./.vitepress/theme/components/pmdrs/VignetteDemo.vue')['default']

--- a/docs/guide/pmndrs/tilt-shift.md
+++ b/docs/guide/pmndrs/tilt-shift.md
@@ -1,0 +1,93 @@
+# Tilt Shift
+
+<DocsDemo>
+  <TiltShiftDemo />
+</DocsDemo>
+
+The `TiltShift` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/TiltShiftEffect.js~TiltShiftEffect.html) package. It allows you to create a tilt-shift effect, simulating a shallow depth of field.
+
+## Usage
+
+The `<TiltShiftPmndrs>` component is straightforward to use and provides customizable options to fine-tune the tilt-shift effect.
+
+```vue{2,19-22,47-51}
+<script setup lang="ts">
+import { EffectComposerPmndrs, TiltShiftPmndrs } from '@tresjs/post-processing'
+
+const colors = [
+  '#FF5733',
+  '#33FF57',
+  '#3357FF',
+  '#FF33A1',
+  '#33FFF5',
+  '#FF5733',
+  '#FF8D33',
+]
+
+const gl = {
+  toneMapping: NoToneMapping,
+  multisampling: 8,
+}
+
+const effectProps = {
+  focusArea: 0.7,
+  feather: 0.2,
+}
+</script>
+
+<template>
+   <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[0, 8, 4]" />
+    <OrbitControls auto-rotate />
+
+    <template v-for="index in 50" :key="index">
+      <TresMesh :position="[(index % 10) * 3 - 13.5, 0, Math.floor(index / 10) * 3 - 7.5]" :scale="[2, Math.random() * 5 + 2, 2]">
+        <TresBoxGeometry :args="[1, 1, 1]" />
+        <TresMeshPhysicalMaterial
+          :color="colors[index % colors.length]"
+          :roughness="0.35"
+          :metalness="0.5"
+          :clearcoat="0.3"
+          :clearcoatRoughness="0.25"
+        />
+      </TresMesh>
+    </template>
+
+    <Suspense>
+      <Environment background :blur=".35" preset="city" />
+    </Suspense>
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <TiltShiftPmndrs v-bind="effectProps" />
+      </EffectComposerPmndrs>
+    </Suspense>
+
+    <ContactShadows
+      :opacity=".75"
+      :position-y="-3.5"
+      :scale="20"
+      :blur=".1"
+      :far="15"
+    />
+  </TresCanvas>
+</template>
+```
+
+## Props
+
+| Prop              | Description                                                                                                                                                                  | Default                  |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| **blendFunction** | Defines how the effect blends with the original scene. <br> See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options. | `BlendFunction.NORMAL`   |
+| **offset**        | The relative offset of the focus area. A positive value shifts the focus area upwards, while a negative value shifts it downwards. <br> Range: `[-0.5, 0.5]`.  | `0.0`                    |
+| **rotation**      | The rotation of the focus area in radians. A positive rotation turns the focus area clockwise, while a negative rotation turns it counterclockwise. <br> Range: `[-π, π]`. | `0.0`                    |
+| **focusArea**     | The relative size of the focus area. A higher value increases the size of the focus area, while a lower value reduces it. <br> Range: `[0, 1]`. | `0.4`                    |
+| **feather**       | The softness of the focus area edges. A higher value makes the edges softer, while a lower value makes them sharper. <br> Range: `[0, 1]`.  | `0.3`                    |
+| **kernelSize**    | The blur kernel size. A larger kernel size produces a more pronounced blur. <br> See the [`KernelSize`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-KernelSize) options.  | `KernelSize.MEDIUM`      |
+| **resolutionScale** | The resolution scale. A higher value increases the effect's resolution, while a lower value reduces it, affecting quality and performance. <br> Range: `[0.1, 1]`.  | `0.5`                    |
+| **resolutionX**   | The horizontal resolution. Use `Resolution.AUTO_SIZE` for automatic sizing based on the scene's resolution. | `Resolution.AUTO_SIZE`   |
+| **resolutionY**   | The vertical resolution. Use `Resolution.AUTO_SIZE` for automatic sizing based on the scene's resolution. | `Resolution.AUTO_SIZE`   |
+
+## Further Reading
+
+For more details, see the [TiltShift documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/TiltShiftEffect.js~TiltShiftEffect.html).

--- a/playground/src/pages/postprocessing/tilt-shift.vue
+++ b/playground/src/pages/postprocessing/tilt-shift.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { Environment, OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { TresLeches, useControls } from '@tresjs/leches'
+import { EffectComposerPmndrs, TiltShiftPmndrs } from '@tresjs/post-processing'
+import { BlendFunction, KernelSize, Resolution } from 'postprocessing'
+import { NoToneMapping } from 'three'
+
+import '@tresjs/leches/styles'
+
+const gl = {
+  toneMapping: NoToneMapping,
+  multisampling: 8,
+}
+
+const { blendFunction, offset, rotation, focusArea, feather, kernelSize, resolutionScale, resolutionX, resolutionY } = useControls({
+  blendFunction: {
+    options: Object.keys(BlendFunction).map(key => ({
+      text: key,
+      value: BlendFunction[key],
+    })),
+    value: BlendFunction.NORMAL,
+  },
+  offset: { value: 0.0, min: -0.5, max: 0.5, step: 0.01 },
+  rotation: { value: 0.0, min: -Math.PI, max: Math.PI, step: 0.01 },
+  focusArea: { value: 0.4, min: 0, max: 1, step: 0.01 },
+  feather: { value: 0.3, min: 0, max: 1, step: 0.01 },
+  kernelSize: {
+    options: Object.keys(KernelSize).map(key => ({
+      text: key,
+      value: KernelSize[key],
+    })),
+    value: KernelSize.MEDIUM,
+  },
+  resolutionScale: { value: 0.5, min: 0.1, max: 1, step: 0.1 },
+  resolutionX: { value: Resolution.AUTO_SIZE, min: 0, max: 2048, step: 1 },
+  resolutionY: { value: Resolution.AUTO_SIZE, min: 0, max: 2048, step: 1 },
+})
+</script>
+
+<template>
+  <TresLeches />
+
+  <TresCanvas
+    v-bind="gl"
+  >
+    <TresPerspectiveCamera
+      :position="[5, 5, 6]"
+      :look-at="[0, 0, 0]"
+    />
+    <OrbitControls auto-rotate />
+
+    <TresGridHelper :position="[0, -3, 0]" />
+
+    <TresMesh :position="[0, 2, 0]">
+      <TresBoxGeometry :args="[2, 2, 2]" />
+      <TresMeshPhysicalMaterial color="#FF5733" :roughness="1" :transmission="0" />
+    </TresMesh>
+
+    <TresMesh :position="[0, 0, 0]">
+      <TresBoxGeometry :args="[2, 2, 2]" />
+      <TresMeshPhysicalMaterial color="#33FF57" :roughness="1" :transmission="0" />
+    </TresMesh>
+
+    <TresMesh :position="[0, -2, 0]">
+      <TresBoxGeometry :args="[2, 2, 2]" />
+      <TresMeshPhysicalMaterial color="#3357FF" :roughness="1" :transmission="0" />
+    </TresMesh>
+
+    <Suspense>
+      <Environment background :blur=".25" preset="modern" />
+    </Suspense>
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <TiltShiftPmndrs
+          :blendFunction="Number(blendFunction.value)"
+          :offset="offset.value"
+          :rotation="rotation.value"
+          :focusArea="focusArea.value"
+          :feather="feather.value"
+          :kernelSize="Number(kernelSize.value)"
+          :resolutionScale="resolutionScale.value"
+          :resolutionX="resolutionX.value"
+          :resolutionY="resolutionY.value"
+        />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
+</template>

--- a/playground/src/router.ts
+++ b/playground/src/router.ts
@@ -36,6 +36,7 @@ export const postProcessingRoutes = [
   makeRoute('Glitch', '📺', false),
   makeRoute('Depth of Field', '📷', false),
   makeRoute('Hue & Saturation', '📷', false),
+  makeRoute('Tilt Shift', '🔍', false),
   makeRoute('Pixelation', '👾', false),
   makeRoute('Bloom', '🌼', false),
   makeRoute('Noise', '📟', false),

--- a/src/core/pmndrs/HueSaturationPmndrs.vue
+++ b/src/core/pmndrs/HueSaturationPmndrs.vue
@@ -21,7 +21,6 @@ export interface HueSaturationPmndrsProps {
    * The blend function. Defines how the effect blends with the original scene.
    */
   blendFunction?: BlendFunction
-
 }
 
 const props = withDefaults(

--- a/src/core/pmndrs/TiltShiftPmndrs.vue
+++ b/src/core/pmndrs/TiltShiftPmndrs.vue
@@ -1,0 +1,92 @@
+<script lang="ts" setup>
+import type { BlendFunction } from 'postprocessing'
+import { KernelSize, Resolution, TiltShiftEffect } from 'postprocessing'
+import { makePropWatchers } from '../../util/prop'
+import { useEffectPmndrs } from './composables/useEffectPmndrs'
+
+export interface TiltShiftPmndrsProps {
+  /**
+   * The blend function. Defines how the effect blends with the original scene.
+   */
+  blendFunction?: BlendFunction
+
+  /**
+   * The relative offset of the focus area.
+   * Range: [-0.5, 0.5]
+   */
+  offset?: number
+
+  /**
+   * The rotation of the focus area in radians.
+   * Range: [-π, π]
+   */
+  rotation?: number
+
+  /**
+   * The relative size of the focus area.
+   * Range: [0, 1]
+   */
+  focusArea?: number
+
+  /**
+   * The softness of the focus area edges.
+   * Range: [0, 1]
+   */
+  feather?: number
+
+  /**
+   * The blur kernel size.
+   */
+  kernelSize?: KernelSize
+
+  /**
+   * The resolution scale.
+   * Range: [0.1, 1]
+   */
+  resolutionScale?: number
+
+  /**
+   * The horizontal resolution.
+   */
+  resolutionX?: number
+
+  /**
+   * The vertical resolution.
+   */
+  resolutionY?: number
+}
+
+const props = withDefaults(
+  defineProps<TiltShiftPmndrsProps>(),
+  {
+    offset: 0.0,
+    rotation: 0.0,
+    focusArea: 0.4,
+    feather: 0.3,
+    kernelSize: KernelSize.MEDIUM,
+    resolutionScale: 0.5,
+    resolutionX: Resolution.AUTO_SIZE,
+    resolutionY: Resolution.AUTO_SIZE,
+  },
+)
+
+const { pass, effect } = useEffectPmndrs(() => new TiltShiftEffect(props), props)
+
+defineExpose({ pass, effect })
+
+makePropWatchers(
+  [
+    [() => props.blendFunction, 'blendMode.blendFunction'],
+    [() => props.offset, 'offset'],
+    [() => props.rotation, 'rotation'],
+    [() => props.focusArea, 'focusArea'],
+    [() => props.feather, 'feather'],
+    [() => props.kernelSize, 'kernelSize'],
+    [() => props.resolutionScale, 'resolutionScale'],
+    [() => props.resolutionX, 'resolutionX'],
+    [() => props.resolutionY, 'resolutionY'],
+  ],
+  effect,
+  () => new TiltShiftEffect(),
+)
+</script>

--- a/src/core/pmndrs/index.ts
+++ b/src/core/pmndrs/index.ts
@@ -12,6 +12,7 @@ import VignettePmndrs, { type VignettePmndrsProps } from './VignettePmndrs.vue'
 import ChromaticAberrationPmndrs, { type ChromaticAberrationPmndrsProps } from './ChromaticAberration.vue'
 import HueSaturationPmndrs, { type HueSaturationPmndrsProps } from './HueSaturationPmndrs.vue'
 import ScanlinePmndrs, { type ScanlinePmndrsProps } from './ScanlinePmndrs.vue'
+import TiltShiftPmndrs, { type TiltShiftPmndrsProps } from './TiltShiftPmndrs.vue'
 
 export {
   BloomPmndrs,
@@ -26,6 +27,8 @@ export {
   ChromaticAberrationPmndrs,
   HueSaturationPmndrs,
   ScanlinePmndrs,
+  TiltShiftPmndrs,
+
   BloomPmndrsProps,
   DepthOfFieldPmndrsProps,
   EffectComposerPmndrsProps,
@@ -37,4 +40,5 @@ export {
   ChromaticAberrationPmndrsProps,
   HueSaturationPmndrsProps,
   ScanlinePmndrsProps,
+  TiltShiftPmndrsProps,
 }


### PR DESCRIPTION
This component introduces the `TiltShift` effect, which provides an abstraction for applying a tilt-shift effect, simulating a shallow depth of field. The `<TiltShiftPmndrs>` effect is specifically designed to add dynamic and immersive visual effects by blurring parts of the scene, enhancing artistic quality and realism.

- Easy to set up — simply include it in your `<EffectComposerPmndrs>` pipeline.
- Multiple options for controlling focus area, feather, and blend functions are available.
- Fully supports different blend functions for enhanced customization.

For more details, see [TiltShiftEffect on pmndrs/postprocessing](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/TiltShiftEffect.js~TiltShiftEffect.html).

___

Local Playground — `pnpm run playground`

Local Documentation — `pnpm run docs:dev`
