### PR TITLE
fix: add exported member depth picking pass pmndrs

### DIFF
--- a/src/core/pmndrs/index.ts
+++ b/src/core/pmndrs/index.ts
@@ -22,6 +22,7 @@ import TiltShiftPmndrs, { type TiltShiftPmndrsProps } from './TiltShiftPmndrs.vu
 import DotScreenPmndrs, { type DotScreenPmndrsProps } from './DotScreenPmndrs.vue'
 import SepiaPmndrs, { type SepiaPmndrsProps } from './SepiaPmndrs.vue'
 import LinocutPmndrs, { type LinocutPmndrsProps } from './LinocutPmndrs.vue'
+import DepthPickingPassPmndrs, { type DepthPickingPassPmndrsProps } from './DepthPickingPassPmndrs.vue'
 
 export {
   BloomPmndrs,
@@ -46,6 +47,7 @@ export {
   DotScreenPmndrs,
   SepiaPmndrs,
   LinocutPmndrs,
+  DepthPickingPassPmndrs,
   BloomPmndrsProps,
   DepthOfFieldPmndrsProps,
   EffectComposerPmndrsProps,
@@ -67,4 +69,5 @@ export {
   DotScreenPmndrsProps,
   SepiaPmndrsProps,
   LinocutPmndrsProps,
+  DepthPickingPassPmndrsProps,
 }

--- a/src/core/three/UnrealBloom.vue
+++ b/src/core/three/UnrealBloom.vue
@@ -32,21 +32,21 @@ defineExpose({ pass })
 
 watchEffect(() => {
   pass.value.radius = props.radius
-  ?? pass.value.getCompositeMaterial().uniforms.bloomRadius?.value
-  ?? 0.1
+    ?? pass.value.getCompositeMaterial().uniforms.bloomRadius?.value
+    ?? 0.1
 })
 
 watchEffect(() => {
   pass.value.strength
   = props.strength
-  ?? pass.value.getCompositeMaterial().uniforms.bloomStrength?.value
-  ?? 1
+    ?? pass.value.getCompositeMaterial().uniforms.bloomStrength?.value
+    ?? 1
 })
 
 watchEffect(() => {
   pass.value.threshold
   = props.threshold
-  ?? LuminosityHighPassShader.uniforms.luminosityThreshold?.value
-  ?? 1
+    ?? LuminosityHighPassShader.uniforms.luminosityThreshold?.value
+    ?? 1
 })
 </script>


### PR DESCRIPTION
The DepthPickingPassPmndrs export was removed by mistake, causing issues with ShockWave. 
This PR restores it to ensure proper functionality.