### PR TITLE
docs: clean demos

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -46,10 +46,13 @@ You can import post-processing effects from both pmndrs and native Three.js. All
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :args="[45," 1, 0.1, 1000] />
-    <EffectComposer>
-      <UnrealBloom />
-      <Glitch />
-    </EffectComposer>
+
+    <Suspense>
+      <EffectComposer>
+        <UnrealBloom />
+        <Glitch />
+      </EffectComposer>
+    </Suspense>
   </TresCanvas>
 </template>
 ```
@@ -66,10 +69,13 @@ You can also use Pmndrs `postprocessing` effects, but you need to use the `Effec
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :args="[45," 1, 0.1, 1000] />
-    <EffectComposerPmndrs>
-      <BloomPmndrs />
-      <GlitchPmndrs />
-    </EffectComposerPmndrs>
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <BloomPmndrs />
+        <GlitchPmndrs />
+      </EffectComposerPmndrs>
+    </Suspense>
   </TresCanvas>
 </template>
 ```

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -38,14 +38,14 @@ You can import post-processing effects from both pmndrs and native Three.js. All
 
 ### Using native Three.js effects
 
-```html
+```vue{2,9-14}
 <script setup lang="ts">
-  import { EffectComposer, UnrealBloom, Glitch } from '@tresjs/post-processing'
+import { EffectComposer, Glitch, UnrealBloom } from '@tresjs/post-processing'
 </script>
 
 <template>
   <TresCanvas shadows alpha>
-    <TresPerspectiveCamera :args="[45," 1, 0.1, 1000] />
+    <TresPerspectiveCamera :args="[45, 1, 0.1, 1000]" />
 
     <Suspense>
       <EffectComposer>
@@ -61,14 +61,14 @@ You can import post-processing effects from both pmndrs and native Three.js. All
 
 You can also use Pmndrs `postprocessing` effects, but you need to use the `EffectComposerPmndrs` component instead of `EffectComposer` and suffix the effects with `Pmndrs`.
 
-```html
+```vue{2,9-14}
 <script setup lang="ts">
-  import { EffectComposerPmndrs, BloomPmndrs, GlitchPmndrs } from '@tresjs/post-processing'
+import { BloomPmndrs, EffectComposerPmndrs, GlitchPmndrs } from '@tresjs/post-processing'
 </script>
 
 <template>
   <TresCanvas shadows alpha>
-    <TresPerspectiveCamera :args="[45," 1, 0.1, 1000] />
+    <TresPerspectiveCamera :args="[45, 1, 0.1, 1000]" />
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/barrel-blur.md
+++ b/docs/guide/pmndrs/barrel-blur.md
@@ -4,17 +4,23 @@
   <BarrelBlurDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/BarrelBlurDemo.vue{0}
+</details>
+
 The `Barrel Blur` is a custom effect that applies a barrel distortion with chromatic aberration blur, providing a unique visual effect.
 
 ## Usage
 
 The `<BarrelBlurPmndrs>` component is straightforward to use and provides customizable options to fine-tune the barrel blur effect.
 
-```vue{4,11-14,39-43}
+```vue{3,11-14,21-25}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { Environment, OrbitControls, RoundedBox } from '@tresjs/cientos'
 import { EffectComposerPmndrs, BarrelBlurPmndrs } from '@tresjs/post-processing'
+import { NoToneMapping } from 'three'
 
 const gl = {
   clearColor: '#4f4f4f',
@@ -29,25 +35,7 @@ const effectProps = {
 
 <template>
   <TresCanvas v-bind="gl">
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-      :look-at="[0, 0, 0]"
-    />
-    <OrbitControls auto-rotate />
-
-    <Suspense>
-      <Environment preset="shangai" />
-    </Suspense>
-
-    <RoundedBox :args="[2, 2, 2, 2, 0.25]">
-      <TresMeshPhysicalMaterial
-        color="white"
-        :metalness=".9"
-        :roughness=".5"
-        :clearcoat="1.0"
-        :clearcoatRoughness="0.1"
-      />
-    </RoundedBox>
+    <TresPerspectiveCamera :position="[5, 5, 5]"/>
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/chromatic-aberration.md
+++ b/docs/guide/pmndrs/chromatic-aberration.md
@@ -4,53 +4,42 @@
   <ChromaticAberrationDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/ChromaticAberrationDemo.vue{0}
+</details>
+
 The `ChromaticAberration` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ChromaticAberrationEffect.js~ChromaticAberrationEffect.html) package. It simulates the dispersion of light as it passes through a lens, creating subtle or dramatic color fringing effects at the edges of objects. This effect can enhance the visual appeal of your scene by adding a realistic lens effect or a stylized touch.
 
 ## Usage
 
 The `<ChromaticAberrationPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{2,34-42}
+```vue{2,10-14,21-25}
 <script setup lang="ts">
-import { EffectComposerPmndrs, ChromaticAberrationPmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, ChromaticAberrationPmndrs } from '@tresjs/post-processing'
 import { Vector2 } from 'three'
+import { NoToneMapping } from 'three'
 
 const gl = {
   toneMapping: NoToneMapping,
 }
 
-const offset = new Vector2(0.07, 0.07)
+const effectProps = {
+  offset: new Vector2(0.07, 0.07),
+  radialModulation: true,
+  modulationOffset: 0
+}
 </script>
 
 <template>
   <TresCanvas v-bind="gl">
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-    />
-
-    <template
-      v-for="i in 4"
-      :key="i"
-    >
-      <TresMesh
-        :position="[((i - 1) - (4 - 1) / 2) * 1.5, 0, 0]"
-      >
-        <TresBoxGeometry
-          :width="4"
-          :height="4"
-          :depth="4"
-        />
-        <TresMeshStandardMaterial color="#1C1C1E" />
-      </TresMesh>
-    </template>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>
-        <ChromaticAberrationPmndrs
-          :offset
-          radial-modulation
-          :modulation-offset="0"
-        />
+        <ChromaticAberrationPmndrs v-bind="effectProps" />
       </EffectComposerPmndrs>
     </Suspense>
   </TresCanvas>
@@ -61,7 +50,7 @@ const offset = new Vector2(0.07, 0.07)
 
 | Prop              | Description                                                                                                   | Default                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| blendFunction     | Defines the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) used for the effect.                                                               | `BlendFunction.SRC`       |
+| blendFunction     | Defines how the effect blends with the original scene. See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options.                                                               | `BlendFunction.SRC`       |
 | offset            | The color offset vector determining the intensity and direction of chromatic aberration.                     | `Vector2(0.01, 0.01)`     |
 | radialModulation  | Enables radial modulation to vary the effect intensity based on distance from the center.                    | `false`                   |
 | modulationOffset  | Specifies the modulation offset when `radialModulation` is **enabled**.                                          | `0.15`                    |
@@ -71,4 +60,4 @@ The `modulationOffset` property is functional only when `radialModulation` is en
 :::
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html)
+For more details, see the [ChromaticAberration documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ChromaticAberrationEffect.js~ChromaticAberrationEffect.html)

--- a/docs/guide/pmndrs/color-average.md
+++ b/docs/guide/pmndrs/color-average.md
@@ -4,49 +4,37 @@
   <ColorAverageDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/ColorAverageDemo.vue{0}
+</details>
+
 The `ColorAverage` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ColorAverageEffect.js~ColorAverageEffect.html) package. It averages the colors of the scene, creating a unique visual effect. This effect can be used to achieve a variety of artistic styles.
 
 ## Usage
 
 The `<ColorAveragePmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{6,14-17,38-42}
+```vue{4,11-13,20-24}
 <script setup lang="ts">
-import { Environment, OrbitControls } from '@tresjs/cientos'
 import { TresCanvas } from '@tresjs/core'
 import { NoToneMapping } from 'three'
-import { BlendFunction } from 'postprocessing'
 import { ColorAveragePmndrs, EffectComposerPmndrs } from '@tresjs/post-processing'
 
 const gl = {
-  clearColor: '#ffffff',
+  clearColor: '#ff0000',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const effectProps = reactive({
-  blendFunction: BlendFunction.NORMAL,
   opacity: 0.5
 })
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
-    <TresPerspectiveCamera
-      :position="[5, 2, 15]"
-    />
-    <OrbitControls auto-rotate />
-
-    <TresMesh :position="[0, 3.5, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshPhysicalMaterial color="#8B0000" :roughness=".25" />
-    </TresMesh>
-
-    <Suspense>
-      <Environment background preset="shangai" />
-    </Suspense>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[5, 5, 5]"/>
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -61,7 +49,7 @@ const effectProps = reactive({
 
 | Prop              | Description                                                                                                   | Default                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| blendFunction     | Defines the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) used for the effect.                                                               | `BlendFunction.NORMAL`    |
+| blendFunction     | Defines how the effect blends with the original scene. See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options.                                                               | `BlendFunction.NORMAL`    |
 | opacity           | Sets the opacity of the color average effect.                                                                 | `1`                       |
 
 ## Further Reading

--- a/docs/guide/pmndrs/dot-screen.md
+++ b/docs/guide/pmndrs/dot-screen.md
@@ -4,15 +4,20 @@
   <DotScreenDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/DotScreenDemo.vue{0}
+</details>
+
 The `DotScreen` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/DotScreenEffect.js~DotScreenEffect.html) package. It allows you to create a dot screen effect, providing flexibility for artistic effects.
 
 ## Usage
 
 The `<DotScreenPmndrs>` component is straightforward to use and provides customizable options to fine-tune the dot screen effect.
 
-```vue{4,12-15,40-44}
+```vue{3,11-14,21-25}
 <script setup lang="ts">
-import { ContactShadows, Environment, OrbitControls, useGLTF } from '@tresjs/cientos'
 import { TresCanvas } from '@tresjs/core'
 import { DotScreenPmndrs, EffectComposerPmndrs } from '@tresjs/post-processing'
 import { NoToneMapping } from 'three'
@@ -26,29 +31,11 @@ const effectProps = reactive({
   angle: 1.57,
   scale: 1.25
 })
-
-const { scene } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/suzanne/suzanne.glb', { draco: true })
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
-    <TresPerspectiveCamera
-      :position="[0, 1, 7.5]"
-    />
-    <OrbitControls />
-
-    <primitive :scale="2" :rotation-x="Math.PI / -5" :rotation-y="Math.PI" :position-y=".25" :position-z="0.5" :object="scene" />
-
-    <ContactShadows
-      :opacity="1"
-      :position-y="-1.5"
-    />
-
-    <Suspense>
-      <Environment preset="modern" />
-    </Suspense>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/hue-saturation.md
+++ b/docs/guide/pmndrs/hue-saturation.md
@@ -4,16 +4,28 @@
   <HueSaturationDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/HueSaturationDemo.vue{0}
+</details>
+
 The `HueSaturation` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/HueSaturationEffect.js~HueSaturationEffect.html) package. It allows you to adjust the hue and saturation of your scene, providing flexibility for color grading and artistic effects.
 
 ## Usage
 
 The `<HueSaturationPmndrs>` component is straightforward to use and provides customizable options to fine-tune the hue and saturation of your visuals.
 
-```vue{2,5-9,26-32}
+```vue{2,11-15,22-26}
 <script setup lang="ts">
 import { EffectComposerPmndrs, HueSaturationPmndrs } from '@tresjs/post-processing'
 import { BlendFunction } from 'postprocessing'
+import { NoToneMapping } from 'three'
+
+const gl = {
+  clearColor: '#00ff00',
+  toneMapping: NoToneMapping,
+}
 
 const effectProps = {
   saturation: 1,
@@ -23,24 +35,12 @@ const effectProps = {
 </script>
 
 <template>
-  <TresCanvas>
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-      :look-at="[0, 0, 0]"
-    />
-
-    <OrbitControls auto-rotate />
-
-    <TresMesh :position="[0, 1, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshPhysicalMaterial color="white" />
-    </TresMesh>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>
-        <HueSaturationPmndrs
-          v-bind="effectProps"
-        />
+        <HueSaturationPmndrs v-bind="effectProps" />
       </EffectComposerPmndrs>
     </Suspense>
   </TresCanvas>

--- a/docs/guide/pmndrs/kuwahara.md
+++ b/docs/guide/pmndrs/kuwahara.md
@@ -4,6 +4,12 @@
   <KuwaharaDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/KuwaharaDemo.vue{0}
+</details>
+
 The `Kuwahara` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/KuwaharaEffect.js~KuwaharaEffect.html) package. It allows you to apply a Kuwahara filter to your scene, providing a painterly effect.
 
 The Kuwahara effect smooths out an image while keeping the edges sharp. It splits the image into small parts, checks each part for differences, and uses the part with the least differences. This makes the image look like a painting, reducing noise but keeping important details.
@@ -12,37 +18,30 @@ The Kuwahara effect smooths out an image while keeping the edges sharp. It split
 
 The `<KuwaharaPmndrs>` component is straightforward to use and provides customizable options to fine-tune the Kuwahara effect.
 
-```vue{2,5-9,26-32}
+```vue{3,11-14,21-25}
 <script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, KuwaharaPmndrs } from '@tresjs/post-processing'
-import { BlendFunction } from 'postprocessing'
+import { NoToneMapping } from 'three'
+
+const gl = {
+  clearColor: '#0ff000',
+  toneMapping: NoToneMapping,
+}
 
 const effectProps = reactive({
   radius: 1,
-  blendFunction: BlendFunction.NORMAL,
   sectorCount: 4,
 })
 </script>
 
 <template>
-  <TresCanvas>
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-      :look-at="[0, 0, 0]"
-    />
-
-    <OrbitControls auto-rotate />
-
-    <TresMesh :position="[0, 1, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshPhysicalMaterial color="green" />
-    </TresMesh>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>
-        <KuwaharaPmndrs
-          v-bind="effectProps"
-        />
+        <KuwaharaPmndrs v-bind="effectProps" />
       </EffectComposerPmndrs>
     </Suspense>
   </TresCanvas>

--- a/docs/guide/pmndrs/lens-distortion.md
+++ b/docs/guide/pmndrs/lens-distortion.md
@@ -4,20 +4,27 @@
   <LensDistortionDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/LensDistortionDemo.vue{0}
+</details>
+
 The `LensDistortion` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/LensDistortionEffect.js~LensDistortionEffect.html) package. It allows you to apply a lens distortion effect to your scene, providing flexibility for creating realistic camera effects.
 
 ## Usage
 
 The `<LensDistortionPmndrs>` component is straightforward to use and provides customizable options to fine-tune the distortion effect of your visuals.
 
-```vue{3,11-16,51-55}
+```vue{2,12-17,24-28}
 <script setup lang="ts">
-import { Vector2 } from 'three'
 import { EffectComposerPmndrs, LensDistortionPmndrs } from '@tresjs/post-processing'
-import { Environment, OrbitControls } from '@tresjs/cientos'
-import { TresCanvas, useTexture } from '@tresjs/core'
+import { Vector2 } from 'three'
+import { TresCanvas } from '@tresjs/core'
+import { NoToneMapping } from 'three'
 
 const gl = {
+  clearColor: '#0ff000',
   toneMapping: NoToneMapping,
 }
 
@@ -27,39 +34,11 @@ const effectProps = {
   focalLength: new Vector2(0.5, 0.5),
   skew: 0,
 }
-
-const pbrTexture = await useTexture({
-  map: '/lens-distortion/room-map.png',
-  normalMap: '/lens-distortion/room-normal.png',
-})
-
-pbrTexture.map.colorSpace = SRGBColorSpace
 </script>
 
 <template>
-   <TresCanvas
-    v-bind="gl"
-  >
-    <TresPerspectiveCamera
-      :position="[-2, 1, 5]"
-    />
-    <OrbitControls auto-rotate />
-
-    <TresMesh :position="[0, 2, 0]">
-      <TresBoxGeometry :args="[8, 8, 8]" />
-      <TresMeshStandardMaterial :side="BackSide" :map="pbrTexture.map" :normal-map="pbrTexture.normalMap" />
-    </TresMesh>
-
-    <TresMesh :position="[0, 0, 0]">
-      <TresBoxGeometry :args="[1.65, 1.65, 1.65]" />
-      <TresMeshNormalMaterial />
-    </TresMesh>
-
-    <TresAmbientLight :intensity="2" />
-
-    <Suspense>
-      <Environment background :blur=".25" preset="snow" />
-    </Suspense>
+   <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/linocut.md
+++ b/docs/guide/pmndrs/linocut.md
@@ -4,17 +4,23 @@
   <LinocutDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/LinocutDemo.vue{0}
+</details>
+
 The `Linocut` effect is a custom shader effect inspired by traditional linocut and woodcut printmaking. It transforms the scene into a high-contrast black-and-white composition, featuring bold lines and intricate patterns that replicate the handcrafted aesthetic of relief printing techniques.
 
 ## Usage
 
 The `<LinocutPmndrs>` component is straightforward to use and provides customizable options to fine-tune the linocut effect.
 
-```vue{4,11-17,36-40}
+```vue{3,11-16,23-27}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { Environment, OrbitControls } from '@tresjs/cientos'
 import { EffectComposerPmndrs, LinocutPmndrs } from '@tresjs/post-processing'
+import { NoToneMapping } from 'three'
 
 const gl = {
   clearColor: '#4f4f4f',
@@ -26,25 +32,12 @@ const effectProps = reactive({
   noiseScale: 0.0,
   center: [0.5, 0.5],
   rotation: 0.0,
-  blendFunction: BlendFunction.NORMAL,
 })
 </script>
 
 <template>
   <TresCanvas v-bind="gl">
-    <TresPerspectiveCamera
-      :position="[0, 6.5, 6.5]"
-    />
-    <OrbitControls auto-rotate />
-
-    <Suspense>
-      <Environment preset="shangai" />
-    </Suspense>
-
-    <TresMesh>
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshStandardMaterial color="yellow" />
-    </TresMesh>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/scanline.md
+++ b/docs/guide/pmndrs/scanline.md
@@ -4,23 +4,30 @@
   <ScanlineDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/ScanlineDemo.vue{0}
+</details>
+
 The `Scanline` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ScanlineEffect.js~ScanlineEffect.html) package. It simulates scanlines reminiscent of old CRT displays, creating a nostalgic or stylized visual effect for your scene. This effect can enhance the retro aesthetic of your project or add a unique visual touch.
 
 ## Usage
 
 The `<ScanlinePmndrs>` component is easy to use and provides customizable options to achieve the desired visual appearance.
 
-```vue{2,9-14,25-31}
+```vue{3,11-15,22-26}
 <script setup lang="ts">
-import { EffectComposerPmndrs, ScanlinePmndrs } from '@tresjs/post-processing/pmndrs'
-import { BlendFunction } from 'postprocessing'
+import { TresCanvas } from '@tresjs/core'
+import { EffectComposerPmndrs, ScanlinePmndrs } from '@tresjs/post-processing'
+import { NoToneMapping } from 'three'
 
 const gl = {
+  clearColor: '#0ff000',
   toneMapping: NoToneMapping,
 }
 
 const effectProps = {
-  blendFunction: BlendFunction.HARD_MIX,
   density: 1.25,
   opacity: 0.65,
   scrollSpeed: 0.05,
@@ -28,18 +35,12 @@ const effectProps = {
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-    />
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>
-        <ScanlinePmndrs
-          v-bind="effectProps"
-        />
+        <ScanlinePmndrs v-bind="effectProps" />
       </EffectComposerPmndrs>
     </Suspense>
   </TresCanvas>
@@ -50,11 +51,11 @@ const effectProps = {
 
 | Prop              | Description                                                                                                   | Default                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| blendFunction     | Defines the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) used for the effect.                                                               | `BlendFunction.OVERLAY`   |
+| blendFunction     | Defines how the effect blends with the original scene. See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options.                                                               | `BlendFunction.OVERLAY`   |
 | density           | The density of the scanlines. Higher values increase the frequency of lines.                                  | `1.25`                    |
 | opacity           | The opacity of the scanlines. Controls the transparency of the effect.                                       | `1.0`                     |
 | scrollSpeed       | The speed at which the scanlines scroll vertically. When set to `0`, the scanlines remain static. Any non-zero value animates the scanlines vertically. | `0.0`                     |
 
 ## Further Reading
 
-See [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ScanlineEffect.js~ScanlineEffect.html)
+For more details, see the [Scanline documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ScanlineEffect.js~ScanlineEffect.html)

--- a/docs/guide/pmndrs/sepia.md
+++ b/docs/guide/pmndrs/sepia.md
@@ -4,15 +4,23 @@
   <SepiaDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/SepiaDemo.vue{0}
+</details>
+
 The `Sepia` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/SepiaEffect.js~SepiaEffect.html) package. It applies a sepia tone to the scene, giving it a warm, antique appearance. This effect can enhance the visual appeal of your scene by adding a vintage or stylized touch.
 
 ## Usage
 
 The `<SepiaPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{2,33-37}
+```vue{3,15-19}
 <script setup lang="ts">
-import { EffectComposerPmndrs, SepiaPmndrs } from '@tresjs/post-processing/pmndrs'
+import { TresCanvas } from '@tresjs/core'
+import { EffectComposerPmndrs, SepiaPmndrs } from '@tresjs/post-processing'
+import { NoToneMapping } from 'three'
 
 const gl = {
   toneMapping: NoToneMapping,
@@ -20,28 +28,8 @@ const gl = {
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-    />
-
-    <OrbitControls auto-rotate />
-
-    <TresMesh :position="[0, .5, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshPhysicalMaterial color="black" :roughness=".25" />
-    </TresMesh>
-
-    <ContactShadows
-      :opacity="1"
-      :position-y="-.5"
-    />
-
-    <Suspense>
-      <Environment background :blur=".5" preset="snow" />
-    </Suspense>
+  <TresCanvas v-bind="gl" >
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/shock-wave.md
+++ b/docs/guide/pmndrs/shock-wave.md
@@ -26,12 +26,11 @@ You can use various Tres.js events such as `click`, `pointer-enter`, etc., to tr
 
 Here is an example of how to use events to trigger the shockwave effect:
 
-```vue{2,3,12-14,16-17,19-20,22-23,25-27,29-35,43,48-56}
+```vue{2,46-54}
 <script setup lang="ts">
 import { EffectComposerPmndrs, ShockWavePmndrs } from '@tresjs/post-processing'
 import { useMouse, useWindowSize } from '@vueuse/core'
 import { NoToneMapping, Vector3 } from 'three'
-import { computed, ref } from 'vue'
 import { TresCanvas } from '@tresjs/core'
 
 const gl = {
@@ -42,8 +41,8 @@ const effectProps = {
   speed: 0.2,
 }
 
-const position = ref(new Vector3(0, 0, 0))
 const shockWaveEffectRef = ref(null)
+const mousePosition = ref(new Vector3(0,0,0))
 
 const { x, y } = useMouse()
 const { width, height } = useWindowSize()
@@ -66,9 +65,8 @@ function triggerShockWave() {
 
 <template>
   <TresCanvas v-bind="gl">
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-    />
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
     <TresMesh @click="triggerShockWave">
       <TresBoxGeometry />
       <TresMeshStandardMaterial color="#1C1C1E" />
@@ -78,7 +76,7 @@ function triggerShockWave() {
       <EffectComposerPmndrs>
         <ShockWavePmndrs
           ref="shockWaveEffectRef"
-          :position="position"
+          :position="mousePosition"
           v-bind="effectProps"
         />
       </EffectComposerPmndrs>
@@ -93,13 +91,18 @@ The `DepthPickingPassPmndrs` component reads depth information from the scene. T
 
 In the example above, `DepthPickingPassPmndrs` determines the depth of the point where the shockwave effect should originate, allowing accurate interaction with 3D objects.
 
-```vue{2,3,13-15,17-20,22-23,25-26,28-37,39-45,51,58,63-72}
+```vue{2,64-73}
 <script setup lang="ts">
 import { DepthPickingPassPmndrs, EffectComposerPmndrs, ShockWavePmndrs } from '@tresjs/post-processing'
 import { useMouse, useWindowSize } from '@vueuse/core'
 import { NoToneMapping, Vector3 } from 'three'
-import { computed, ref } from 'vue'
 import { TresCanvas } from '@tresjs/core'
+
+/**
+ * The camera value is retrieved via a ref here (elCanvasRef) because using
+ * https://docs.tresjs.org/api/composables.html#usetrescontext
+ * is not possible at the same level as <TresCanvas>.
+ */
 
 const gl = {
   toneMapping: NoToneMapping,
@@ -109,7 +112,7 @@ const effectProps = {
   speed: 0.2,
 }
 
-const position = ref(new Vector3(0, 0, 0))
+const mousePosition = ref(new Vector3(0, 0, 0))
 const depthPickingPassRef = ref(null)
 const shockWaveEffectRef = ref(null)
 const elCanvasRef = ref(null)
@@ -128,7 +131,7 @@ async function updateMousePosition() {
   ndcPosition.z = await depthPickingPassRef.value.pass.readDepth(ndcPosition)
   ndcPosition.z = ndcPosition.z * 2.0 - 1.0
 
-  position.value.copy(ndcPosition.unproject(elCanvasRef.value.context.camera.value))
+  mousePosition.value.copy(ndcPosition.unproject(elCanvasRef.value.context.camera.value))
 }
 
 function triggerShockWave() {
@@ -145,10 +148,7 @@ function triggerShockWave() {
     v-bind="gl"
     ref="elCanvasRef"
   >
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-      :look-at="[0, 0, 0]"
-    />
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <TresMesh @click="triggerShockWave">
       <TresBoxGeometry />
@@ -160,7 +160,7 @@ function triggerShockWave() {
         <DepthPickingPassPmndrs ref="depthPickingPassRef" />
         <ShockWavePmndrs
           ref="shockWaveEffectRef"
-          :position="position"
+          :position="mousePosition"
           v-bind="effectProps"
         />
       </EffectComposerPmndrs>
@@ -182,4 +182,4 @@ For more details about DepthPickingPass, see the [documentation](https://pmndrs.
 | maxRadius         | The max radius of the shockwave.                                                                              | `1.0`                     |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ShockWaveEffect.js~ShockWaveEffect.html)
+For more details, see the [ShockWave documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ShockWaveEffect.js~ShockWaveEffect.html)

--- a/docs/guide/pmndrs/tilt-shift.md
+++ b/docs/guide/pmndrs/tilt-shift.md
@@ -4,29 +4,26 @@
   <TiltShiftDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/TiltShiftDemo.vue{0}
+</details>
+
 The `TiltShift` effect is part of the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/TiltShiftEffect.js~TiltShiftEffect.html) package. It allows you to create a tilt-shift effect, simulating a shallow depth of field.
 
 ## Usage
 
 The `<TiltShiftPmndrs>` component is straightforward to use and provides customizable options to fine-tune the tilt-shift effect.
 
-```vue{3,20-23,48-52}
+```vue{3,11-14,21-25}
 <script setup lang="ts">
-import { Environment, OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, TiltShiftPmndrs } from '@tresjs/post-processing'
 import { NoToneMapping } from 'three'
 
-const colors = [
-  '#FF5733',
-  '#33FF57',
-  '#3357FF',
-  '#FF33A1',
-  '#33FFF5',
-  '#FF5733',
-  '#FF8D33',
-]
-
 const gl = {
+  clearColor: '#0ff000',
   toneMapping: NoToneMapping,
 }
 
@@ -38,33 +35,13 @@ const effectProps = {
 
 <template>
    <TresCanvas v-bind="gl">
-    <TresPerspectiveCamera :position="[0, 4, 8]" />
-    <OrbitControls auto-rotate />
-
-    <template v-for="index in 50" :key="index">
-      <TresMesh :position="[(index % 10) * 3 - 13.5, 0, Math.floor(index / 10) * 3 - 7.5]" :scale="[2, Math.random() * 5 + 2, 2]">
-        <TresBoxGeometry :args="[1, 1, 1]" />
-        <TresMeshPhysicalMaterial
-          :color="colors[index % colors.length]"
-          :roughness="0.35"
-          :metalness="0.5"
-          :clearcoat="0.3"
-          :clearcoatRoughness="0.25"
-        />
-      </TresMesh>
-    </template>
-
-    <Suspense>
-      <Environment background :blur=".35" preset="snow" />
-    </Suspense>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>
         <TiltShiftPmndrs v-bind="effectProps" />
       </EffectComposerPmndrs>
     </Suspense>
-
-    <TresGridHelper :position="[0, -3.5, 0]" :args="[30, 15]" />
   </TresCanvas>
 </template>
 ```
@@ -73,7 +50,7 @@ const effectProps = {
 
 | Prop              | Description                                                                                                                                                                  | Default                  |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| **blendFunction** | Defines how the effect blends with the original scene. <br> See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options. | `BlendFunction.NORMAL`   |
+| **blendFunction** | Defines how the effect blends with the original scene. See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options. | `BlendFunction.NORMAL`   |
 | **offset**        | The relative offset of the focus area. A positive value shifts the focus area upwards, while a negative value shifts it downwards. <br> Range: `[-0.5, 0.5]`.  | `0.0`                    |
 | **rotation**      | The rotation of the focus area in radians. A positive rotation turns the focus area clockwise, while a negative rotation turns it counterclockwise. <br> Range: `[-π, π]`. | `0.0`                    |
 | **focusArea**     | The relative size of the focus area. A higher value increases the size of the focus area, while a lower value reduces it. <br> Range: `[0, 1]`. | `0.4`                    |

--- a/docs/guide/pmndrs/tone-mapping.md
+++ b/docs/guide/pmndrs/tone-mapping.md
@@ -4,6 +4,12 @@
   <ToneMappingDemo />
 </DocsDemo>
 
+<details>
+  <summary>Demo code</summary>
+
+  <<< @/.vitepress/theme/components/pmdrs/ToneMappingDemo.vue{0}
+</details>
+
 The `ToneMapping` effect from the [`postprocessing`](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html) package provides an abstraction for various tone mapping algorithms to improve the visual rendering of HDR (high dynamic range) content. Tone mapping is used to map high-range brightness values to a range that is displayable on standard screens. This effect contributes significantly to the visual quality of your scene by controlling luminance and color balance.
 
 ::: info
@@ -14,10 +20,11 @@ If the colors in your scene look incorrect after adding the EffectComposer, it m
 
 The `<ToneMappingPmndrs>` component is easy to set up and comes with multiple tone mapping modes to suit different visual requirements. Below is an example of how to use it in a Vue application.
 
-```vue{2,4,7-8,30-34}
+```vue{3,5,7-10,12-14,21-25}
 <script setup lang="ts">
-import { EffectComposerPmndrs, ToneMappingPmndrs } from '@tresjs/post-processing/pmndrs'
-import { onUnmounted, shallowRef } from 'vue'
+import { TresCanvas } from '@tresjs/core'
+import { EffectComposerPmndrs, ToneMappingPmndrs } from '@tresjs/post-processing'
+import { NoToneMapping } from 'three'
 import { ToneMappingMode } from 'postprocessing'
 
 const gl = {
@@ -25,28 +32,18 @@ const gl = {
   toneMapping: NoToneMapping,
 }
 
-const modelRef = shallowRef(null)
-
-const { scene: model } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/realistic-pokeball/scene.gltf', { draco: true })
-
-onUnmounted(() => {
-  dispose(modelRef.value)
-})
+const effectProps = {
+  mode: ToneMappingMode.AGX,
+}
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
-    <TresPerspectiveCamera
-      :position="[5, 5, 5]"
-    />
-
-    <primitive ref="modelRef" :object="model" />
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
     <Suspense>
       <EffectComposerPmndrs>
-        <ToneMappingPmndrs :mode="ToneMappingMode.AGX" />
+        <ToneMappingPmndrs v-bind="effectProps" />
       </EffectComposerPmndrs>
     </Suspense>
   </TresCanvas>
@@ -58,7 +55,7 @@ onUnmounted(() => {
 | Prop              | Description                                                                                                   | Default                                                                                           |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | mode              | Tone mapping mode used, defined by [`ToneMappingMode`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-ToneMappingMode).                                                         | `ToneMappingMode.AGX`                                                                             |
-| blendFunction     | Defines the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) used for the effect.                                                               | `BlendFunction.SRC`                                                                               |
+| blendFunction     | Defines how the effect blends with the original scene. See the [`BlendFunction`](https://pmndrs.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction) options.                                                               | `BlendFunction.SRC`                                                                               |
 | resolution        | Resolution of the luminance texture (must be a power of two, e.g., 256, 512, etc.).                           | `256`                                                                                             |
 | averageLuminance  | Average luminance value used in adaptive calculations. Only applicable to `ToneMappingMode.REINHARD2`                        | `1.0`                                                                                             |
 | middleGrey        | Factor to adjust the balance of grey in luminance calculations. Only applicable to `ToneMappingMode.REINHARD2`               | `0.6`                                                                                             |


### PR DESCRIPTION
This PR cleans up the usage demos in the documentation (those from version >V2.0) to improve readability. Although the demos have been streamlined, it was still essential to provide users with the complete source code. To achieve this, an expandable menu has been added below each demo, allowing users to view the demo's code.

I've also modified the demos in the documentation introduction. The <Suspense> tags were missing.

___

Are demos still too massive, or is that okay? 

Because the imports can be removed, I just think it's important to keep `<TresPerspectiveCamera />` to understand the level at which to activate `<EffectComposerPmndrs />`.

I haven't modified @Tinoooo demos (before version 2.0), I may do so later when we've agreed on a “basic model” of demo usage style. 
___

The branch is deliberately based on the [fix/bad-use-multisampling branch](https://github.com/Tresjs/post-processing/pull/188). I also based the PR directly on the `bad-use-multisampling` branch instead of `main`. I don't know if that's a good practice or not, you tell me! 
![Capture d’écran 2025-02-16 à 17 41 44](https://github.com/user-attachments/assets/bfd3f68a-dbbd-4b15-8de8-61b6a5ffc0e4)
