### PR TITLE
fix: god rays async light source

### DIFF
--- a/playground/src/pages/postprocessing/god-rays.vue
+++ b/playground/src/pages/postprocessing/god-rays.vue
@@ -5,6 +5,7 @@ import { TresLeches, useControls } from '@tresjs/leches'
 import { NoToneMapping } from 'three'
 import { BlendFunction, KernelSize, Resolution } from 'postprocessing'
 import { EffectComposerPmndrs, GodRaysPmndrs } from '@tresjs/post-processing'
+import { shallowRef } from 'vue'
 
 import '@tresjs/leches/styles'
 
@@ -14,8 +15,7 @@ const gl = {
   multisampling: 8,
 }
 
-const boxMeshRef = ref(null)
-const sphereMeshRef = ref(null)
+const sphereMeshRef = shallowRef(null)
 
 const { blur, kernelSize, resolutionX, resolutionY, resolutionScale, opacity, blendFunction, density, decay, weight, exposure, samples, clampMax } = useControls({
   blendFunction: {
@@ -69,7 +69,7 @@ const { blur, kernelSize, resolutionX, resolutionY, resolutionScale, opacity, bl
       <TresMeshBasicMaterial color="#FFDDAA" />
     </TresMesh>
 
-    <TresMesh ref="boxMeshRef" :position="[0, .5, 0]">
+    <TresMesh :position="[0, .5, 0]">
       <TresBoxGeometry :args="[2, 2, 2]" />
       <TresMeshBasicMaterial color="white" />
     </TresMesh>

--- a/src/core/pmndrs/GodRaysPmndrs.vue
+++ b/src/core/pmndrs/GodRaysPmndrs.vue
@@ -4,7 +4,7 @@ import { GodRaysEffect } from 'postprocessing'
 import { makePropWatchers } from '../../util/prop'
 import { useEffectPmndrs } from './composables/useEffectPmndrs'
 import { useTresContext } from '@tresjs/core'
-import { ref, shallowRef, toRaw, watch } from 'vue'
+import { toRaw, watch } from 'vue'
 import type { Mesh, Points } from 'three'
 
 export interface GodRaysPmndrsProps {

--- a/src/core/pmndrs/GodRaysPmndrs.vue
+++ b/src/core/pmndrs/GodRaysPmndrs.vue
@@ -16,7 +16,7 @@ export interface GodRaysPmndrsProps {
   /**
    * The light source. Must not write depth and has to be flagged as transparent.
    */
-  lightSource?: Mesh | Points
+  lightSource?: Mesh | Points | null
 
   /**
    * The opacity of the God Rays.
@@ -84,7 +84,7 @@ const props = defineProps<GodRaysPmndrsProps>()
 const { camera } = useTresContext()
 
 const { pass, effect } = useEffectPmndrs(
-  () => new GodRaysEffect(camera.value, toRaw(props.lightSource), props),
+  () => new GodRaysEffect(camera.value, toRaw(props.lightSource) || undefined, props),
   props,
 )
 
@@ -116,9 +116,21 @@ watch(
       effect.value?.blendMode.setOpacity(props.opacity)
     }
     else {
-      const plainEffect = new GodRaysEffect(camera.value, toRaw(props.lightSource))
+      const plainEffect = new GodRaysEffect(camera.value, props.lightSource ? toRaw(props.lightSource) : undefined)
       effect.value?.blendMode.setOpacity(plainEffect.blendMode.getOpacity())
       plainEffect.dispose()
+    }
+  },
+  {
+    immediate: true,
+  },
+)
+
+watch(
+  [() => props.lightSource, effect],
+  () => {
+    if (effect.value && props.lightSource) {
+      effect.value.lightSource = toRaw(props.lightSource)
     }
   },
   {

--- a/src/core/pmndrs/GodRaysPmndrs.vue
+++ b/src/core/pmndrs/GodRaysPmndrs.vue
@@ -84,13 +84,13 @@ const props = defineProps<GodRaysPmndrsProps>()
 
 const { camera } = useTresContext()
 
-const dummyMesh = new Mesh(
+const resolvedLightSource = props.lightSource ?? new Mesh(
   new SphereGeometry(0.00001),
   new MeshBasicMaterial({ visible: false }),
 )
 
 const { pass, effect } = useEffectPmndrs(
-  () => new GodRaysEffect(camera.value, dummyMesh, props),
+  () => new GodRaysEffect(camera.value, resolvedLightSource, props),
   props,
 )
 
@@ -118,8 +118,10 @@ makePropWatchers(
 watch(
   [() => props.lightSource, effect],
   () => {
-    if (props.lightSource && effect.value) {
-      effect.value.lightSource = toRaw(props.lightSource)
+    if (effect.value) {
+      effect.value.lightSource = props.lightSource
+        ? toRaw(props.lightSource)
+        : resolvedLightSource
     }
   },
   { immediate: true },
@@ -132,7 +134,10 @@ watch(
       effect.value?.blendMode.setOpacity(props.opacity)
     }
     else {
-      const plainEffect = new GodRaysEffect(camera.value, toRaw(props.lightSource))
+      const plainEffect = new GodRaysEffect(
+        camera.value,
+        props.lightSource ? toRaw(props.lightSource) : resolvedLightSource,
+      )
       effect.value?.blendMode.setOpacity(plainEffect.blendMode.getOpacity())
       plainEffect.dispose()
     }

--- a/src/core/pmndrs/GodRaysPmndrs.vue
+++ b/src/core/pmndrs/GodRaysPmndrs.vue
@@ -84,13 +84,11 @@ const props = defineProps<GodRaysPmndrsProps>()
 
 const { camera } = useTresContext()
 
-const dummyLightSource = new Mesh(
-  new SphereGeometry(0.00001),
-  new MeshBasicMaterial({ visible: false }),
-)
-
 const resolvedLightSource = computed(() =>
-  props.lightSource ?? dummyLightSource,
+  props.lightSource ?? new Mesh(
+    new SphereGeometry(0.00001),
+    new MeshBasicMaterial({ visible: false }),
+  ),
 )
 
 const { pass, effect } = useEffectPmndrs(
@@ -112,8 +110,8 @@ makePropWatchers(
     [() => props.resolutionScale, 'resolution.scale'],
     [() => props.resolutionX, 'resolution.width'],
     [() => props.resolutionY, 'resolution.height'],
-    [() => props.kernelSize, 'kernelSize'],
-    [() => props.blur, 'blur'],
+    [() => props.kernelSize, 'blurPass.kernelSize'],
+    [() => props.blur, 'blurPass.enabled'],
   ],
   effect,
   () => new GodRaysEffect(),


### PR DESCRIPTION
This PR fixes a light source issue ([Discord message](https://discord.com/channels/1047126995424780288/1110586781558116494/1354922195880640593)) in `<GodRaysPmndrs>`. The source (mesh or point) wasn't handling async creation properly, causing missing or incorrect GodRays.

Godrays doesn't accept null lightSource (only `Mesh` | `Points`), so I've added a dummyMesh that allows the Godrays effect to have a temporary placeholder. It's then modified by the real value of props.lightSource when it's ready.