### PR TITLE
fix: big clean demo — docs —  bad using multisampling

### DIFF
--- a/docs/.vitepress/theme/components/pmdrs/BrightnessContrastDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/BrightnessContrastDemo.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const { brightness, contrast, blendFunction } = useControls({
@@ -20,7 +19,7 @@ const { brightness, contrast, blendFunction } = useControls({
   blendFunction: {
     options: Object.keys(BlendFunction).map(key => ({
       text: key,
-      value: BlendFunction[key],
+      value: BlendFunction[key as keyof typeof BlendFunction],
     })),
     value: BlendFunction.SRC,
   },

--- a/docs/.vitepress/theme/components/pmdrs/ColorAverageDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/ColorAverageDemo.vue
@@ -14,7 +14,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {

--- a/docs/.vitepress/theme/components/pmdrs/ColorDepthDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/ColorDepthDemo.vue
@@ -14,7 +14,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const ctx = gsap.context(() => {})

--- a/docs/.vitepress/theme/components/pmdrs/FishEyeDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/FishEyeDemo.vue
@@ -15,7 +15,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const lensParams = [

--- a/docs/.vitepress/theme/components/pmdrs/GridDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/GridDemo.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const { blendFunction, scale, lineWidth } = useControls({

--- a/docs/.vitepress/theme/components/pmdrs/LinocutDemo.vue
+++ b/docs/.vitepress/theme/components/pmdrs/LinocutDemo.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#00ff00',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {

--- a/docs/guide/pmndrs/barrel-blur.md
+++ b/docs/guide/pmndrs/barrel-blur.md
@@ -16,7 +16,7 @@ The `Barrel Blur` is a custom effect that applies a barrel distortion with chrom
 
 The `<BarrelBlurPmndrs>` component is straightforward to use and provides customizable options to fine-tune the barrel blur effect.
 
-```vue{3,11-14,21-25}
+```vue{3,11-14,23-27}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, BarrelBlurPmndrs } from '@tresjs/post-processing'
@@ -36,6 +36,8 @@ const effectProps = {
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]"/>
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/bloom.md
+++ b/docs/guide/pmndrs/bloom.md
@@ -8,21 +8,29 @@ Bloom is an effect that simulates the way that bright objects in the real world 
 
 ## Usage
 
-```vue
+```vue{2,11-21}
 <script setup lang="ts">
 import { BloomPmndrs, EffectComposerPmndrs } from '@tresjs/post-processing'
 </script>
 
 <template>
-  <EffectComposerPmndrs>
-    <BloomPmndrs
-      :radius="0.85"
-      :intensity="4.0"
-      :luminance-threshold="0.1"
-      :luminance-smoothing="0.3"
-      mipmap-blur
-    />
-  </EffectComposerPmndrs>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <BloomPmndrs
+          :radius="0.85"
+          :intensity="4.0"
+          :luminance-threshold="0.1"
+          :luminance-smoothing="0.3"
+          mipmap-blur
+        />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
 </template>
 ```
 
@@ -38,4 +46,4 @@ import { BloomPmndrs, EffectComposerPmndrs } from '@tresjs/post-processing'
 | `mipMapBlur`         | Enables mip map blur (UnrealBloom).                                                                  | `false`                                                                                                                                        |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/BloomEffect.js~BloomEffect.html)
+For more details, see the [BloomEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/BloomEffect.js~BloomEffect.html)

--- a/docs/guide/pmndrs/brightness-contrast.md
+++ b/docs/guide/pmndrs/brightness-contrast.md
@@ -17,13 +17,12 @@ It adjusts the brightness and contrast of your scene.
 
 The `<BrightnessContrastPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{2,9-13,27-31}
+```vue{2,8-12,21-25}
 <script setup lang="ts">
 import { EffectComposerPmndrs, BrightnessContrastPmndrs } from '@tresjs/post-processing/pmndrs'
 
 const gl = {
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const effectProps = {
@@ -34,15 +33,10 @@ const effectProps = {
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas v-bind="gl">
     <TresPerspectiveCamera />
 
-    <TresMesh :position="[0, .5, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshPhysicalMaterial color="black" :roughness=".25" />
-    </TresMesh>
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -62,4 +56,4 @@ const effectProps = {
 | contrast      | The contrast factor, where 0 means no change. <br> Range: `[-1.0, 1.0]`                   | `0`                         |
 
 ## Further Reading
-For more details, see the [BrightnessContrast documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/BrightnessContrastEffect.js~BrightnessContrastEffect.html)
+For more details, see the [BrightnessContrastEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/BrightnessContrastEffect.js~BrightnessContrastEffect.html)

--- a/docs/guide/pmndrs/chromatic-aberration.md
+++ b/docs/guide/pmndrs/chromatic-aberration.md
@@ -16,7 +16,7 @@ The `ChromaticAberration` effect is part of the [`postprocessing`](https://pmndr
 
 The `<ChromaticAberrationPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{2,10-14,21-25}
+```vue{2,10-14,23-27}
 <script setup lang="ts">
 import { EffectComposerPmndrs, ChromaticAberrationPmndrs } from '@tresjs/post-processing'
 import { Vector2 } from 'three'
@@ -36,6 +36,8 @@ const effectProps = {
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -60,4 +62,4 @@ The `modulationOffset` property is functional only when `radialModulation` is en
 :::
 
 ## Further Reading
-For more details, see the [ChromaticAberration documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ChromaticAberrationEffect.js~ChromaticAberrationEffect.html)
+For more details, see the [ChromaticAberrationEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ChromaticAberrationEffect.js~ChromaticAberrationEffect.html)

--- a/docs/guide/pmndrs/color-average.md
+++ b/docs/guide/pmndrs/color-average.md
@@ -16,7 +16,7 @@ The `ColorAverage` effect is part of the [`postprocessing`](https://pmndrs.githu
 
 The `<ColorAveragePmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{4,11-13,20-24}
+```vue{4,11-13,22-26}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { NoToneMapping } from 'three'
@@ -27,14 +27,16 @@ const gl = {
   toneMapping: NoToneMapping,
 }
 
-const effectProps = reactive({
+const effectProps = {
   opacity: 0.5
-})
+}
 </script>
 
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]"/>
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -53,4 +55,4 @@ const effectProps = reactive({
 | opacity           | Sets the opacity of the color average effect.                                                                 | `1`                       |
 
 ## Further Reading
-For more details, see the [ColorAverage documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ColorAverageEffect.js~ColorAverageEffect.html)
+For more details, see the [ColorAverageEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ColorAverageEffect.js~ColorAverageEffect.html)

--- a/docs/guide/pmndrs/color-depth.md
+++ b/docs/guide/pmndrs/color-depth.md
@@ -17,13 +17,12 @@ It renders a ColorDepth that can be scaled or adjusted to achieve a variety of v
 
 The `<ColorDepthPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{2,9-13,25-29}
+```vue{2,8-12,21-25}
 <script setup lang="ts">
 import { EffectComposerPmndrs, ColorDepthPmndrs } from '@tresjs/post-processing/pmndrs'
 
 const gl = {
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const effectProps = {
@@ -37,10 +36,7 @@ const effectProps = {
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera />
 
-    <TresMesh :position="[0, .5, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshNormalMaterial />
-    </TresMesh>
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/depth-of-field.md
+++ b/docs/guide/pmndrs/depth-of-field.md
@@ -10,15 +10,23 @@ This photographic technique allows photographers and filmmakers to draw attentio
 
 ## Usage
 
-```vue
+```vue{2,11-15}
 <script setup lang="ts">
 import { DepthOfFieldPmndrs, EffectComposerPmndrs } from '@tresjs/post-processing'
 </script>
 
 <template>
-  <EffectComposerPmndrs>
-    <DepthOfFieldPmndrs />
-  </EffectComposerPmndrs>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <DepthOfFieldPmndrs :focus-range="0.5" />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
 </template>
 ```
 
@@ -34,4 +42,4 @@ import { DepthOfFieldPmndrs, EffectComposerPmndrs } from '@tresjs/post-processin
 | `bokehScale` | The scale of the bokeh blur. | 1.0 |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/DepthOfFieldEffect.js~DepthOfFieldEffect.html)
+For more details, see the [DepthOfFieldEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/DepthOfFieldEffect.js~DepthOfFieldEffect.html)

--- a/docs/guide/pmndrs/dot-screen.md
+++ b/docs/guide/pmndrs/dot-screen.md
@@ -16,7 +16,7 @@ The `DotScreen` effect is part of the [`postprocessing`](https://pmndrs.github.i
 
 The `<DotScreenPmndrs>` component is straightforward to use and provides customizable options to fine-tune the dot screen effect.
 
-```vue{3,11-14,21-25}
+```vue{3,11-14,23-27}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { DotScreenPmndrs, EffectComposerPmndrs } from '@tresjs/post-processing'
@@ -27,15 +27,17 @@ const gl = {
   toneMapping: NoToneMapping,
 }
 
-const effectProps = reactive({
+const effectProps = {
   angle: 1.57,
   scale: 1.25
-})
+}
 </script>
 
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -56,4 +58,4 @@ const effectProps = reactive({
 
 ## Further Reading
 
-For more details, see the [DotScreen documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/DotScreenEffect.js~DotScreenEffect.html).
+For more details, see the [DotScreenEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/DotScreenEffect.js~DotScreenEffect.html).

--- a/docs/guide/pmndrs/fish-eye.md
+++ b/docs/guide/pmndrs/fish-eye.md
@@ -16,7 +16,7 @@ The `FishEye` is a custom effect simulates the wide-angle distortion of a fish-e
 
 The `<FishEyePmndrs>` component is straightforward to use and provides customizable options to fine-tune the fish-eye effect.
 
-```vue{3,12-17,29-33}
+```vue{3,11-16,25-29}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, FishEyePmndrs } from '@tresjs/post-processing'
@@ -25,14 +25,13 @@ import { BlendFunction } from 'postprocessing'
 const gl = {
   clearColor: '#4f4f4f',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const effectProps = {
   blendFunction: BlendFunction.NORMAL,
-  lensS: [1.0, 1.0],
-  lensF: [0.0, 1.0],
-  scale: 1.0,
+  lensS: [1.0, 0.65],
+  lensF: [0.25, 1.0],
+  scale: 0.85,
 }
 </script>
 
@@ -40,10 +39,7 @@ const effectProps = {
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
 
-    <TresMesh>
-      <TresSphereGeometry :args="[5, 32, 32]" />
-      <TresMeshPhysicalMaterial :metalness="0.5" :roughness="0.25" />
-    </TresMesh>
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/fxaa.md
+++ b/docs/guide/pmndrs/fxaa.md
@@ -72,4 +72,4 @@ const effectProps = {
 | subpixelQuality | The subpixel blend quality. Range: `[0.0, 1.0]`.             | `0.75`        |
 
 ## Further Reading
-For more details, see the [FXAAEffectEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/FXAAEffect.js~FXAAEffect.html)
+For more details, see the [FXAAEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/FXAAEffect.js~FXAAEffect.html)

--- a/docs/guide/pmndrs/fxaa.md
+++ b/docs/guide/pmndrs/fxaa.md
@@ -72,4 +72,4 @@ const effectProps = {
 | subpixelQuality | The subpixel blend quality. Range: `[0.0, 1.0]`.             | `0.75`        |
 
 ## Further Reading
-For more details, see the [FXAAEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/FXAAEffect.js~FXAAEffect.html)
+For more details, see the [FXAAEffectEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/FXAAEffect.js~FXAAEffect.html)

--- a/docs/guide/pmndrs/glitch.md
+++ b/docs/guide/pmndrs/glitch.md
@@ -14,15 +14,23 @@ This effect may potentially cause epileptic seizures in people with photosensiti
 
 ## Usage
 
-```vue
+```vue{2,11-15}
 <script setup lang="ts">
 import { EffectComposerPmndrs, GlitchPmndrs } from '@tresjs/post-processing'
 </script>
 
 <template>
-  <EffectComposerPmndrs>
-    <GlitchPmndrs />
-  </EffectComposerPmndrs>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <GlitchPmndrs />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
 </template>
 ```
 
@@ -43,4 +51,4 @@ import { EffectComposerPmndrs, GlitchPmndrs } from '@tresjs/post-processing'
 | `dtSize`                    | The size of the generated noise map. Will be ignored if a perturbation map is provided.                            | `64`                                                                                                                                           |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/GlitchEffect.js~GlitchEffect.html)
+For more details, see the [GlitchEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/GlitchEffect.js~GlitchEffect.html)

--- a/docs/guide/pmndrs/god-rays.md
+++ b/docs/guide/pmndrs/god-rays.md
@@ -16,49 +16,42 @@ The `GodRays` effect is part of the [`postprocessing`](https://pmndrs.github.io/
 
 The `<GodRaysPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{5,17-21,40-44}
+```vue{4,13-17,30-37}
 <script setup lang="ts">
-import { OrbitControls } from '@tresjs/cientos'
 import { TresCanvas } from '@tresjs/core'
 import { NoToneMapping } from 'three'
 import { EffectComposerPmndrs, GodRaysPmndrs } from '@tresjs/post-processing'
 
-import '@tresjs/leches/styles'
-
 const gl = {
   clearColor: 'blue',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const sphereMeshRef = ref(null)
 
-const effectProps = reactive({
+const effectProps = {
   opacity: .8,
   exposure: .8,
   resolutionScale: 0.65
-})
+}
 </script>
 
 <template>
   <TresCanvas v-bind="gl">
-    <TresPerspectiveCamera :position="[0, 5, 20]" />
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
 
-    <OrbitControls auto-rotate />
-
+    <!-- The lightSource (in this case a Sphere) -->
     <TresMesh ref="sphereMeshRef" :position="[-10, 8, 0]">
       <TresSphereGeometry :args="[2, 32, 32]" />
       <TresMeshBasicMaterial color="#FFDDAA" :transparent="true" />
     </TresMesh>
 
-    <TresMesh :position="[0, .5, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshBasicMaterial color="white" />
-    </TresMesh>
-
     <Suspense>
       <EffectComposerPmndrs>
-        <GodRaysPmndrs :lightSource="sphereMeshRef" v-bind="effectProps" />
+        <GodRaysPmndrs
+          v-bind="effectProps"
+          :lightSource="sphereMeshRef"
+        />
       </EffectComposerPmndrs>
     </Suspense>
   </TresCanvas>
@@ -85,4 +78,4 @@ const effectProps = reactive({
 | clampMax          | An upper bound for the saturation of the overall effect.                                                      | `1.0`                     |
 
 ## Further Reading
-For more details, see the [GodRays documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/GodRaysEffect.js~GodRaysEffect.html)
+For more details, see the [GodRaysEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/GodRaysEffect.js~GodRaysEffect.html)

--- a/docs/guide/pmndrs/grid.md
+++ b/docs/guide/pmndrs/grid.md
@@ -17,13 +17,12 @@ It renders a grid that can be scaled or adjusted to achieve a variety of visual 
 
 The `<GridPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{2,9-13,25-29}
+```vue{2,8-12,21-25}
 <script setup lang="ts">
 import { EffectComposerPmndrs, GridPmndrs } from '@tresjs/post-processing/pmndrs'
 
 const gl = {
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const effectProps = {
@@ -37,10 +36,7 @@ const effectProps = {
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera />
 
-    <TresMesh :position="[0, .5, 0]">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshToonMaterial color="black" />
-    </TresMesh>
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/hue-saturation.md
+++ b/docs/guide/pmndrs/hue-saturation.md
@@ -16,7 +16,7 @@ The `HueSaturation` effect is part of the [`postprocessing`](https://pmndrs.gith
 
 The `<HueSaturationPmndrs>` component is straightforward to use and provides customizable options to fine-tune the hue and saturation of your visuals.
 
-```vue{2,11-15,22-26}
+```vue{2,11-15,24-28}
 <script setup lang="ts">
 import { EffectComposerPmndrs, HueSaturationPmndrs } from '@tresjs/post-processing'
 import { BlendFunction } from 'postprocessing'
@@ -38,6 +38,8 @@ const effectProps = {
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
 
+    <!-- Your scene -->
+
     <Suspense>
       <EffectComposerPmndrs>
         <HueSaturationPmndrs v-bind="effectProps" />
@@ -57,4 +59,4 @@ const effectProps = {
 
 ## Further Reading
 
-For more details, see the [HueSaturation documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/HueSaturationEffect.js~HueSaturationEffect.html).
+For more details, see the [HueSaturationEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/HueSaturationEffect.js~HueSaturationEffect.html).

--- a/docs/guide/pmndrs/kuwahara.md
+++ b/docs/guide/pmndrs/kuwahara.md
@@ -18,7 +18,7 @@ The Kuwahara effect smooths out an image while keeping the edges sharp. It split
 
 The `<KuwaharaPmndrs>` component is straightforward to use and provides customizable options to fine-tune the Kuwahara effect.
 
-```vue{3,11-14,21-25}
+```vue{3,11-14,23-27}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, KuwaharaPmndrs } from '@tresjs/post-processing'
@@ -29,15 +29,17 @@ const gl = {
   toneMapping: NoToneMapping,
 }
 
-const effectProps = reactive({
+const effectProps = {
   radius: 1,
   sectorCount: 4,
-})
+}
 </script>
 
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/lens-distortion.md
+++ b/docs/guide/pmndrs/lens-distortion.md
@@ -16,7 +16,7 @@ The `LensDistortion` effect is part of the [`postprocessing`](https://pmndrs.git
 
 The `<LensDistortionPmndrs>` component is straightforward to use and provides customizable options to fine-tune the distortion effect of your visuals.
 
-```vue{2,12-17,24-28}
+```vue{2,12-17,26-30}
 <script setup lang="ts">
 import { EffectComposerPmndrs, LensDistortionPmndrs } from '@tresjs/post-processing'
 import { Vector2 } from 'three'
@@ -40,6 +40,8 @@ const effectProps = {
    <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
 
+    <!-- Your scene -->
+
     <Suspense>
       <EffectComposerPmndrs>
         <LensDistortionPmndrs v-bind="effectProps" />
@@ -60,4 +62,4 @@ const effectProps = {
 
 ## Further Reading
 
-For more details, see the [LensDistortion documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/LensDistortionEffect.js~LensDistortionEffect.html).
+For more details, see the [LensDistortionEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/LensDistortionEffect.js~LensDistortionEffect.html).

--- a/docs/guide/pmndrs/linocut.md
+++ b/docs/guide/pmndrs/linocut.md
@@ -16,7 +16,7 @@ The `Linocut` effect is a custom shader effect inspired by traditional linocut a
 
 The `<LinocutPmndrs>` component is straightforward to use and provides customizable options to fine-tune the linocut effect.
 
-```vue{3,11-16,23-27}
+```vue{3,11-16,25-29}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, LinocutPmndrs } from '@tresjs/post-processing'
@@ -27,17 +27,19 @@ const gl = {
   toneMapping: NoToneMapping,
 }
 
-const effectProps = reactive({
+const effectProps = {
   scale: 0.85,
   noiseScale: 0.0,
   center: [0.5, 0.5],
   rotation: 0.0,
-})
+}
 </script>
 
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>

--- a/docs/guide/pmndrs/noise.md
+++ b/docs/guide/pmndrs/noise.md
@@ -8,20 +8,27 @@ Noise is an effect that adds Gaussian noise to the scene. This can be used to si
 
 ## Usage
 
-```vue
+```vue{2,12-19}
 <script setup lang="ts">
 import { BloomPmndrs, EffectComposerPmndrs } from '@tresjs/post-processing'
-
 import { BlendFunction } from 'postprocessing'
 </script>
 
 <template>
-  <EffectComposerPmndrs>
-    <NoisePmndrs
-      premultiply
-      :blend-function="BlendFunction.SCREEN"
-    />
-  </EffectComposerPmndrs>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <NoisePmndrs
+          premultiply
+          :blend-function="BlendFunction.SCREEN"
+        />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
 </template>
 ```
 
@@ -33,4 +40,4 @@ import { BlendFunction } from 'postprocessing'
 | `premultiply`          | Indicates whether noise will be multiplied with the input colors prior to blending | `false`           |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/NoiseEffect.js~NoiseEffect.html)
+For more details, see the [NoiseEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/NoiseEffect.js~NoiseEffect.html)

--- a/docs/guide/pmndrs/outline.md
+++ b/docs/guide/pmndrs/outline.md
@@ -8,15 +8,23 @@ Outline is an effect that applies an outline to objects in your scene. This effe
 
 ## Usage
 
-```vue
+```vue{2,11-15}
 <script setup lang="ts">
 import { EffectComposerPmndrs, OutlinePmndrs } from '@tresjs/post-processing'
 </script>
 
 <template>
-  <EffectComposerPmndrs>
-    <OutlinePmndrs />
-  </EffectComposerPmndrs>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <OutlinePmndrs />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
 </template>
 ```
 
@@ -41,4 +49,4 @@ import { EffectComposerPmndrs, OutlinePmndrs } from '@tresjs/post-processing'
 | visibleEdgeColor | The color of visible edges.                                                                 | 0xffffff                                                                                                                                      |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/OutlineEffect.js~OutlineEffect.html)
+For more details, see the [OutlineEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/OutlineEffect.js~OutlineEffect.html)

--- a/docs/guide/pmndrs/pixelation.md
+++ b/docs/guide/pmndrs/pixelation.md
@@ -8,15 +8,23 @@ Pixelation is an effect that pixelates the scene.
 
 ## Usage
 
-```vue
+```vue{2,11-15}
 <script setup lang="ts">
 import { EffectComposerPmndrs, PixelationPmndrs } from '@tresjs/post-processing'
 </script>
 
 <template>
-  <EffectComposerPmndrs>
-    <PixelationPmndrs />
-  </EffectComposerPmndrs>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <PixelationPmndrs :granularity="15" />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
 </template>
 ```
 
@@ -27,4 +35,4 @@ import { EffectComposerPmndrs, PixelationPmndrs } from '@tresjs/post-processing'
 | granularity | The granularity of the pixels. | 30      |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/PixelationEffect.js~PixelationEffect.html)
+For more details, see the [PixelationEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/PixelationEffect.js~PixelationEffect.html)

--- a/docs/guide/pmndrs/scanline.md
+++ b/docs/guide/pmndrs/scanline.md
@@ -16,7 +16,7 @@ The `Scanline` effect is part of the [`postprocessing`](https://pmndrs.github.io
 
 The `<ScanlinePmndrs>` component is easy to use and provides customizable options to achieve the desired visual appearance.
 
-```vue{3,11-15,22-26}
+```vue{3,11-15,24-28}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, ScanlinePmndrs } from '@tresjs/post-processing'
@@ -38,6 +38,8 @@ const effectProps = {
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
 
+    <!-- Your scene -->
+
     <Suspense>
       <EffectComposerPmndrs>
         <ScanlinePmndrs v-bind="effectProps" />
@@ -58,4 +60,4 @@ const effectProps = {
 
 ## Further Reading
 
-For more details, see the [Scanline documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ScanlineEffect.js~ScanlineEffect.html)
+For more details, see the [ScanlineEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ScanlineEffect.js~ScanlineEffect.html)

--- a/docs/guide/pmndrs/sepia.md
+++ b/docs/guide/pmndrs/sepia.md
@@ -16,7 +16,7 @@ The `Sepia` effect is part of the [`postprocessing`](https://pmndrs.github.io/po
 
 The `<SepiaPmndrs>` component is easy to use and provides customizable options to suit different visual styles.
 
-```vue{3,15-19}
+```vue{3,17-21}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, SepiaPmndrs } from '@tresjs/post-processing'
@@ -30,6 +30,8 @@ const gl = {
 <template>
   <TresCanvas v-bind="gl" >
     <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -48,4 +50,4 @@ const gl = {
 | intensity         | The intensity of the sepia effect.                                                                            | `1.0`                     |
 
 ## Further Reading
-For more details, see the [Sepia documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/SepiaEffect.js~SepiaEffect.html)
+For more details, see the [SepiaEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/SepiaEffect.js~SepiaEffect.html)

--- a/docs/guide/pmndrs/shock-wave.md
+++ b/docs/guide/pmndrs/shock-wave.md
@@ -182,4 +182,4 @@ For more details about DepthPickingPass, see the [documentation](https://pmndrs.
 | maxRadius         | The max radius of the shockwave.                                                                              | `1.0`                     |
 
 ## Further Reading
-For more details, see the [ShockWave documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ShockWaveEffect.js~ShockWaveEffect.html)
+For more details, see the [ShockWaveEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ShockWaveEffect.js~ShockWaveEffect.html)

--- a/docs/guide/pmndrs/tilt-shift.md
+++ b/docs/guide/pmndrs/tilt-shift.md
@@ -16,7 +16,7 @@ The `TiltShift` effect is part of the [`postprocessing`](https://pmndrs.github.i
 
 The `<TiltShiftPmndrs>` component is straightforward to use and provides customizable options to fine-tune the tilt-shift effect.
 
-```vue{3,11-14,21-25}
+```vue{3,11-14,23-27}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, TiltShiftPmndrs } from '@tresjs/post-processing'
@@ -36,6 +36,8 @@ const effectProps = {
 <template>
    <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -62,4 +64,4 @@ const effectProps = {
 
 ## Further Reading
 
-For more details, see the [TiltShift documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/TiltShiftEffect.js~TiltShiftEffect.html).
+For more details, see the [TiltShiftEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/TiltShiftEffect.js~TiltShiftEffect.html).

--- a/docs/guide/pmndrs/tone-mapping.md
+++ b/docs/guide/pmndrs/tone-mapping.md
@@ -20,7 +20,7 @@ If the colors in your scene look incorrect after adding the EffectComposer, it m
 
 The `<ToneMappingPmndrs>` component is easy to set up and comes with multiple tone mapping modes to suit different visual requirements. Below is an example of how to use it in a Vue application.
 
-```vue{3,5,7-10,12-14,21-25}
+```vue{3,5,7-10,12-14,23-27}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { EffectComposerPmndrs, ToneMappingPmndrs } from '@tresjs/post-processing'
@@ -40,6 +40,8 @@ const effectProps = {
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
 
     <Suspense>
       <EffectComposerPmndrs>
@@ -63,4 +65,4 @@ const effectProps = {
 | whitePoint        | White point for tone mapping, used to balance luminance values. Only applicable to `ToneMappingMode.REINHARD2`               | `4.0`                                                                                             |
 
 ## Further Reading
-For more details, see the [Tone Mapping documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html)
+For more details, see the [ToneMappingEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/ToneMappingEffect.js~ToneMappingEffect.html)

--- a/docs/guide/pmndrs/vignette.md
+++ b/docs/guide/pmndrs/vignette.md
@@ -8,18 +8,26 @@ Vignette is an effect that darkens the edges of the scene to make the center pop
 
 ## Usage
 
-```vue
+```vue{2,11-18}
 <script setup lang="ts">
 import { EffectComposerPmndrs, VignettePmndrs } from '@tresjs/post-processing'
 </script>
 
 <template>
-  <EffectComposerPmndrs>
-    <VignettePmndrs
-      :darkness="0.9"
-      :offset="0.2"
-    />
-  </EffectComposerPmndrs>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[5, 5, 5]" />
+
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposerPmndrs>
+        <VignettePmndrs
+          :darkness="0.9"
+          :offset="0.2"
+        />
+      </EffectComposerPmndrs>
+    </Suspense>
+  </TresCanvas>
 </template>
 ```
 
@@ -33,4 +41,4 @@ import { EffectComposerPmndrs, VignettePmndrs } from '@tresjs/post-processing'
 | darkness      | The darkness value.                                          | 0.5                        |
 
 ## Further Reading
-see [postprocessing docs](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/VignetteEffect.js~VignetteEffect.html)
+For more details, see the [VignetteEffect documentation](https://pmndrs.github.io/postprocessing/public/docs/class/src/effects/VignetteEffect.js~VignetteEffect.html)

--- a/playground/src/pages/postprocessing/barrel-blur.vue
+++ b/playground/src/pages/postprocessing/barrel-blur.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {

--- a/playground/src/pages/postprocessing/brightness-contrast.vue
+++ b/playground/src/pages/postprocessing/brightness-contrast.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const { brightness, contrast, blendFunction } = useControls({

--- a/playground/src/pages/postprocessing/chromatic-aberration.vue
+++ b/playground/src/pages/postprocessing/chromatic-aberration.vue
@@ -14,7 +14,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {

--- a/playground/src/pages/postprocessing/color-average.vue
+++ b/playground/src/pages/postprocessing/color-average.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {

--- a/playground/src/pages/postprocessing/color-depth.vue
+++ b/playground/src/pages/postprocessing/color-depth.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const { blendFunction, bits, opacity } = useControls({

--- a/playground/src/pages/postprocessing/fish-eye.vue
+++ b/playground/src/pages/postprocessing/fish-eye.vue
@@ -11,8 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
-  envMapIntensity: 10,
 }
 
 // Note: The variables [lensSX, lensSY], [lensFX, lensFY] are not used as vectors in useControls because the 'step' key is not yet available.

--- a/playground/src/pages/postprocessing/fxaa.vue
+++ b/playground/src/pages/postprocessing/fxaa.vue
@@ -114,7 +114,7 @@ const onChange = (e: { object: PerspectiveCamera }) => {
       </TresMesh>
 
       <Suspense>
-        <EffectComposerPmndrs :multisampling="0">
+        <EffectComposerPmndrs>
           <FXAAPmndrs
             :blendFunction="Number(blendFunction)"
             :opacity="opacity"

--- a/playground/src/pages/postprocessing/god-rays.vue
+++ b/playground/src/pages/postprocessing/god-rays.vue
@@ -12,7 +12,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: 'blue',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const sphereMeshRef = shallowRef(null)

--- a/playground/src/pages/postprocessing/grid.vue
+++ b/playground/src/pages/postprocessing/grid.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  multisampling: 8,
 }
 
 const { blendFunction, scale, lineWidth } = useControls({

--- a/playground/src/pages/postprocessing/linocut.vue
+++ b/playground/src/pages/postprocessing/linocut.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#00ff00',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {

--- a/playground/src/pages/postprocessing/scanline.vue
+++ b/playground/src/pages/postprocessing/scanline.vue
@@ -11,7 +11,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#4f4f4f',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {

--- a/playground/src/pages/postprocessing/shock-wave.vue
+++ b/playground/src/pages/postprocessing/shock-wave.vue
@@ -12,7 +12,6 @@ import '@tresjs/leches/styles'
 const gl = {
   clearColor: '#ffffff',
   toneMapping: NoToneMapping,
-  envMapIntensity: 10,
 }
 
 const glComposer = {


### PR DESCRIPTION
It's a PR designed to clean up documentation / demos.
- Clean up of certain “Usage” parts of the documentation for certain effects.
- Added context templating for some effects (Vignette, Bloom, etc)
- Cleaned up the misuse of multisampling, which could mislead users.