### PR TITLE
fix: update import paths for post-processing components in documentation

### DIFF
--- a/docs/guide/pmndrs/ascii.md
+++ b/docs/guide/pmndrs/ascii.md
@@ -19,7 +19,7 @@ The `<ASCIIPmndrs>` component is straightforward to integrate and offers a varie
 
 ```vue{2,12-17,29-33}
 <script setup lang="ts">
-import { EffectComposerPmndrs, ASCIIPmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, ASCIIPmndrs } from '@tresjs/post-processing'
 
 const gl = {
   toneMapping: NoToneMapping,

--- a/docs/guide/pmndrs/brightness-contrast.md
+++ b/docs/guide/pmndrs/brightness-contrast.md
@@ -19,7 +19,7 @@ The `<BrightnessContrastPmndrs>` component is easy to use and provides customiza
 
 ```vue{2,8-12,21-25}
 <script setup lang="ts">
-import { EffectComposerPmndrs, BrightnessContrastPmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, BrightnessContrastPmndrs } from '@tresjs/post-processing'
 
 const gl = {
   toneMapping: NoToneMapping,

--- a/docs/guide/pmndrs/color-depth.md
+++ b/docs/guide/pmndrs/color-depth.md
@@ -19,7 +19,7 @@ The `<ColorDepthPmndrs>` component is easy to use and provides customizable opti
 
 ```vue{2,8-12,21-25}
 <script setup lang="ts">
-import { EffectComposerPmndrs, ColorDepthPmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, ColorDepthPmndrs } from '@tresjs/post-processing'
 
 const gl = {
   toneMapping: NoToneMapping,

--- a/docs/guide/pmndrs/fxaa.md
+++ b/docs/guide/pmndrs/fxaa.md
@@ -23,7 +23,7 @@ When using the `<EffectComposerPmndrs>` pipeline, enabling native antialiasing w
 
 ```vue{2,12-14,23-27}
 <script setup lang="ts">
-import { EffectComposerPmndrs, FXAAPmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, FXAAPmndrs } from '@tresjs/post-processing'
 
 const gl = {
   toneMapping: NoToneMapping,

--- a/docs/guide/pmndrs/grid.md
+++ b/docs/guide/pmndrs/grid.md
@@ -19,7 +19,7 @@ The `<GridPmndrs>` component is easy to use and provides customizable options to
 
 ```vue{2,8-12,21-25}
 <script setup lang="ts">
-import { EffectComposerPmndrs, GridPmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, GridPmndrs } from '@tresjs/post-processing'
 
 const gl = {
   toneMapping: NoToneMapping,

--- a/docs/guide/pmndrs/smaa.md
+++ b/docs/guide/pmndrs/smaa.md
@@ -26,7 +26,7 @@ When using the `<EffectComposerPmndrs>` pipeline, enabling native antialiasing w
 
 ```vue{2-3,13-15,24-28}
 <script setup lang="ts">
-import { EffectComposerPmndrs, SMAAPmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, SMAAPmndrs } from '@tresjs/post-processing'
 import type { SMAAPreset } from 'postprocessing'
 
 const gl = {

--- a/docs/guide/pmndrs/texture.md
+++ b/docs/guide/pmndrs/texture.md
@@ -24,7 +24,7 @@ If you need to adjust properties such as **rotation**, **repeat**, or **other at
 
 ```vue{2,16-20,41-45}
 <script setup lang="ts">
-import { EffectComposerPmndrs, TexturePmndrs } from '@tresjs/post-processing/pmndrs'
+import { EffectComposerPmndrs, TexturePmndrs } from '@tresjs/post-processing'
 import { TresCanvas, useTexture } from '@tresjs/core'
 import { NoToneMapping, RepeatWrapping, SRGBColorSpace } from 'three'
 import { BlendFunction, ColorChannel } from 'postprocessing'


### PR DESCRIPTION
* Changed import statements in multiple documentation files to use the updated path '@tresjs/post-processing' instead of '@tresjs/post-processing/pmndrs' for consistency and clarity.

Affected files:
- ascii.md
- brightness-contrast.md
- color-depth.md
- fxaa.md
- grid.md
- smaa.md
- texture.md